### PR TITLE
feat(002): SoilDecayService for daily bare-tile decay (PR 2/4)

### DIFF
--- a/LivingRoots/Constants.cs
+++ b/LivingRoots/Constants.cs
@@ -41,5 +41,24 @@ namespace LivingRoots
         public const bool OverlaysEnabledDefault = true;
         public const bool TooltipsEnabledDefault = true;
         public const bool HoeFeedbackEnabledDefault = true;
+
+        // Decay & Compost Constants
+        public const string CompostingBinKeyPrefix = "composting_bins_";
+        public const float DailyDecayRate = 2f;
+        public const float RestorationAmount = 15f;
+        public const int ProcessingDurationMinutes = 2880; // 2 full days × 1440 min/day
+        public const int MaturationMaxLevel = 5;
+        public const int MaturationIdleResetDays = 14;
+        public const int MaturationIncrementDays = 7; // days of continuous operation per level
+        public const string CompostItemId = "LivingRoots.Compost";
+        public const string CompostingBinItemId = "LivingRoots.CompostingBin";
+        public const string CompostingBinRecipeId = "LivingRoots_CompostingBin";
+        public const string CompostCraftingTab = "Home";
+        public const int CompostingBinWoodCost = 50;
+        public const int CompostingBinStoneCost = 25;
+        public const int CompostingBinFiberCost = 15;
+        public const string CompostCraftingSound = "axe";
+        public const int CompostCategoryId = -26;
+        public const int CompostStackMax = 999;
     }
 }

--- a/LivingRoots/Domain/CompostingBinState.cs
+++ b/LivingRoots/Domain/CompostingBinState.cs
@@ -1,0 +1,17 @@
+namespace LivingRoots.Domain;
+
+/// <summary>
+/// Represents the current operational state of a composting bin machine.
+/// State transitions: Empty → Processing → Ready → Empty (cycle repeats).
+/// </summary>
+public enum CompostingBinState
+{
+    /// <summary>Bin is empty and ready to accept organic waste.</summary>
+    Empty = 0,
+
+    /// <summary>Bin is processing input waste into compost.</summary>
+    Processing = 1,
+
+    /// <summary>Bin has finished processing and compost is ready for collection.</summary>
+    Ready = 2
+}

--- a/LivingRoots/Domain/Interfaces/ICompostApplicationService.cs
+++ b/LivingRoots/Domain/Interfaces/ICompostApplicationService.cs
@@ -1,0 +1,22 @@
+using Microsoft.Xna.Framework;
+
+namespace LivingRoots.Domain
+{
+    /// <summary>
+    /// Service for applying compost items to tilled soil to restore health.
+    /// Handles validation, consumption, floating text feedback, and audio cues.
+    /// </summary>
+    public interface ICompostApplicationService
+    {
+        /// <summary>
+        /// Attempts to apply compost to a tile in the specified location.
+        /// Validates tile is tilled, on farm/Greenhouse, and not at max health.
+        /// On success: increases health, consumes compost, shows floating text.
+        /// On failure: plays cancel sound, no visual feedback.
+        /// </summary>
+        /// <param name="location">The game location containing the tile.</param>
+        /// <param name="tile">The tile coordinates to apply compost to.</param>
+        /// <returns>True if compost was successfully applied, false otherwise.</returns>
+        bool TryApplyCompost(StardewValley.GameLocation location, Vector2 tile);
+    }
+}

--- a/LivingRoots/Domain/Interfaces/ICompostingBinService.cs
+++ b/LivingRoots/Domain/Interfaces/ICompostingBinService.cs
@@ -1,0 +1,61 @@
+using Microsoft.Xna.Framework;
+
+namespace LivingRoots.Domain
+{
+    /// <summary>
+    /// Service for managing composting bin machines.
+    /// Handles adding waste, collecting compost, state transitions, maturation, and persistence.
+    /// </summary>
+    public interface ICompostingBinService
+    {
+        /// <summary>
+        /// Adds an organic waste item to the specified composting bin if it is empty and the item is valid.
+        /// </summary>
+        /// <param name="locationName">The location containing the bin.</param>
+        /// <param name="tile">The tile coordinates of the bin.</param>
+        /// <param name="item">The item to add as waste.</param>
+        void AddWaste(string locationName, Vector2 tile, StardewValley.Item item);
+
+        /// <summary>
+        /// Collects finished compost from the specified bin if it is ready.
+        /// </summary>
+        /// <param name="locationName">The location containing the bin.</param>
+        /// <param name="tile">The tile coordinates of the bin.</param>
+        /// <param name="player">The player collecting the compost.</param>
+        /// <returns>The number of compost items produced (equal to maturation level).</returns>
+        int CollectCompost(string locationName, Vector2 tile, StardewValley.Farmer player);
+
+        /// <summary>
+        /// Gets the current state of the composting bin at the specified tile.
+        /// </summary>
+        /// <param name="locationName">The location containing the bin.</param>
+        /// <param name="tile">The tile coordinates of the bin.</param>
+        /// <returns>The current CompostingBinState (Empty, Processing, or Ready).</returns>
+        CompostingBinState GetBinState(string locationName, Vector2 tile);
+
+        /// <summary>
+        /// Processes day start for all bins in a location. Checks processing completion and maturation resets.
+        /// </summary>
+        /// <param name="locationName">The location containing the bins.</param>
+        void ProcessDayStart(string locationName);
+
+        /// <summary>
+        /// Called when a composting bin object is removed/broken. Drops items on ground and clears state.
+        /// </summary>
+        /// <param name="locationName">The location containing the bin.</param>
+        /// <param name="tile">The tile coordinates of the bin.</param>
+        void OnObjectRemoved(string locationName, Vector2 tile);
+
+        /// <summary>
+        /// Loads composting bin data from persistent storage.
+        /// </summary>
+        /// <param name="saveId">The save game ID to load data for.</param>
+        void LoadData(string saveId);
+
+        /// <summary>
+        /// Saves composting bin data to persistent storage.
+        /// </summary>
+        /// <param name="saveId">The save game ID to save data for.</param>
+        void SaveData(string saveId);
+    }
+}

--- a/LivingRoots/Domain/Interfaces/IOrganicWasteValidator.cs
+++ b/LivingRoots/Domain/Interfaces/IOrganicWasteValidator.cs
@@ -1,0 +1,16 @@
+namespace LivingRoots.Domain
+{
+    /// <summary>
+    /// Validates whether an item qualifies as organic waste for composting.
+    /// Validates against vanilla category IDs, custom context tags, and exclusion tags.
+    /// </summary>
+    public interface IOrganicWasteValidator
+    {
+        /// <summary>
+        /// Determines if the specified item is valid organic waste for composting.
+        /// </summary>
+        /// <param name="item">The item to validate.</param>
+        /// <returns>True if the item is valid organic waste, false otherwise.</returns>
+        bool IsValidOrganicWaste(StardewValley.Item item);
+    }
+}

--- a/LivingRoots/Domain/Interfaces/ISoilDecayService.cs
+++ b/LivingRoots/Domain/Interfaces/ISoilDecayService.cs
@@ -1,0 +1,18 @@
+namespace LivingRoots.Domain
+{
+    /// <summary>
+    /// Service responsible for applying daily soil health decay to bare tilled tiles.
+    /// Iterates all tilled tiles at day start, applies seasonal-multiplied decay to bare tiles.
+    /// Dead crop residue acts as mulch protection — decay does not apply to tiles with dead crops.
+    /// Greenhouse is completely exempt from decay.
+    /// </summary>
+    public interface ISoilDecayService
+    {
+        /// <summary>
+        /// Processes all tilled tiles in the specified location and applies daily decay
+        /// to bare tiles (those with no living crop and no dead residue).
+        /// </summary>
+        /// <param name="locationName">The name of the game location to process.</param>
+        void ProcessDayStart(string locationName);
+    }
+}

--- a/LivingRoots/Domain/Models/CompostingBinData.cs
+++ b/LivingRoots/Domain/Models/CompostingBinData.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace LivingRoots.Domain.Models;
+
+/// <summary>
+/// Persisted data for all composting bins across all locations.
+/// Serialized to JSON via IModDataService.
+/// </summary>
+public class CompostingBinData
+{
+    /// <summary>
+    /// Key: location name → key: "X,Y" tile → bin state data.
+    /// </summary>
+    public Dictionary<string, Dictionary<string, CompostingBinStateData>> LocationBinData { get; set; } = new();
+}
+
+/// <summary>
+/// Serializable DTO for a single composting bin's state.
+/// Used for JSON serialization/deserialization.
+/// </summary>
+public class CompostingBinStateData
+{
+    /// <summary>"Empty", "Processing", or "Ready".</summary>
+    public string State { get; set; } = "Empty";
+
+    /// <summary>Qualified item ID of input waste, or null.</summary>
+    public string? InputItemId { get; set; }
+
+    /// <summary>Game time in minutes when waste was added, or null.</summary>
+    public long? InputTimestamp { get; set; }
+
+    /// <summary>Maturation level (1-5).</summary>
+    public int MaturationLevel { get; set; } = 1;
+
+    /// <summary>Consecutive idle days since last activity (0-14).</summary>
+    public int ConsecutiveIdleDays { get; set; } = 0;
+}

--- a/LivingRoots/Domain/Models/CompostingBinStateModel.cs
+++ b/LivingRoots/Domain/Models/CompostingBinStateModel.cs
@@ -1,0 +1,32 @@
+namespace LivingRoots.Domain.Models;
+
+/// <summary>
+/// Runtime state for a single composting bin machine.
+/// Tracks tile position, operational state, input item, maturation, and idle time.
+/// </summary>
+public class CompostingBinStateModel
+{
+    /// <summary>X tile coordinate of the bin.</summary>
+    public int TileX { get; set; }
+
+    /// <summary>Y tile coordinate of the bin.</summary>
+    public int TileY { get; set; }
+
+    /// <summary>Current operational state of the bin.</summary>
+    public CompostingBinState State { get; set; }
+
+    /// <summary>Qualified item ID of the input waste item (null if empty).</summary>
+    public string? InputItemId { get; set; }
+
+    /// <summary>Game time in minutes when waste was added (null if empty).</summary>
+    public long? InputTimestamp { get; set; }
+
+    /// <summary>Current maturation level (1-5), determines output multiplier.</summary>
+    public int MaturationLevel { get; set; } = 1;
+
+    /// <summary>Consecutive days without activity, used for maturation reset.</summary>
+    public int ConsecutiveIdleDays { get; set; } = 0;
+
+    /// <summary>Days of continuous operation, used for maturation increment.</summary>
+    public int ConsecutiveActiveDays { get; set; } = 0;
+}

--- a/LivingRoots/Domain/Services/OrganicWasteValidator.cs
+++ b/LivingRoots/Domain/Services/OrganicWasteValidator.cs
@@ -1,0 +1,54 @@
+using LivingRoots.Domain;
+using StardewModdingAPI;
+using StardewValley;
+
+namespace LivingRoots.Domain.Services;
+
+/// <summary>
+/// Validates whether an item qualifies as organic waste for composting.
+/// Uses hybrid validation: vanilla category IDs OR custom inclusion tag,
+/// with exclusion tag override.
+/// </summary>
+/// <param name="monitor">Logger for trace diagnostics.</param>
+public class OrganicWasteValidator(IMonitor monitor) : IOrganicWasteValidator
+{
+    private readonly IMonitor _monitor = monitor;
+
+    /// <inheritdoc />
+    public bool IsValidOrganicWaste(Item item)
+    {
+        if (item == null)
+        {
+            _monitor.Log("OrganicWasteValidator: null item rejected.", LogLevel.Trace);
+            return false;
+        }
+
+        // Exclusion tag overrides everything — specific items can be excluded
+        if (item.HasContextTag("not_compostable"))
+        {
+            _monitor.Log($"OrganicWasteValidator: {item.QualifiedItemId} rejected (not_compostable tag).", LogLevel.Trace);
+            return false;
+        }
+
+        // Custom inclusion tag for mod compatibility
+        if (item.HasContextTag("compostable_item"))
+        {
+            _monitor.Log($"OrganicWasteValidator: {item.QualifiedItemId} accepted (compostable_item tag).", LogLevel.Trace);
+            return true;
+        }
+
+        // Vanilla category-based validation
+        var isValid = item.Category switch
+        {
+            -74 => true,  // Seeds (wild seeds, tree seeds)
+            -75 => true,  // Vegetables (crop produce)
+            -79 => true,  // Fruits (fruit produce)
+            -80 => true,  // Flowers
+            -81 => true,  // Forage/Greens
+            _ => false
+        };
+
+        _monitor.Log($"OrganicWasteValidator: {item.QualifiedItemId} (category {item.Category}) {(isValid ? "accepted" : "rejected")}.", LogLevel.Trace);
+        return isValid;
+    }
+}

--- a/LivingRoots/Domain/Services/SeasonalDecayMultiplier.cs
+++ b/LivingRoots/Domain/Services/SeasonalDecayMultiplier.cs
@@ -1,0 +1,29 @@
+namespace LivingRoots.Domain.Services;
+
+/// <summary>
+/// Provides season-based decay multipliers for soil health decay calculations.
+/// Higher multiplier in summer (heat stress), lower in spring/fall (mild weather),
+/// zero in winter (soil frozen).
+/// </summary>
+public class SeasonalDecayMultiplier
+{
+    /// <summary>
+    /// Gets the decay multiplier for the specified season.
+    /// </summary>
+    /// <param name="season">Season name (case-insensitive). Expected: "spring", "summer", "fall", "winter".</param>
+    /// <returns>
+    /// Seasonal multiplier: Spring = 0.5x, Summer = 1.5x, Fall = 0.5x, Winter = 0.0x.
+    /// Defaults to 0.5x for unrecognized seasons.
+    /// </returns>
+    public float GetMultiplier(string season)
+    {
+        return season.ToLowerInvariant() switch
+        {
+            "spring" => 0.5f,
+            "summer" => 1.5f,
+            "fall" => 0.5f,
+            "winter" => 0.0f,
+            _ => 0.5f
+        };
+    }
+}

--- a/LivingRoots/Services/SoilDecayService.cs
+++ b/LivingRoots/Services/SoilDecayService.cs
@@ -1,0 +1,83 @@
+using LivingRoots.Domain;
+using LivingRoots.Domain.Services;
+using Microsoft.Xna.Framework;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.TerrainFeatures;
+
+namespace LivingRoots.Services;
+
+/// <summary>
+/// Implementation of ISoilDecayService that processes all tilled tiles
+/// in a location at day start and applies seasonal-multiplied decay to bare tiles.
+/// </summary>
+public class SoilDecayService(
+    ISoilHealthService soilHealthService,
+    IMonitor monitor,
+    SeasonalDecayMultiplier seasonalDecayMultiplier) : ISoilDecayService
+{
+    private readonly ISoilHealthService _soilHealthService = soilHealthService ?? throw new ArgumentNullException(nameof(soilHealthService));
+    private readonly IMonitor _monitor = monitor ?? throw new ArgumentNullException(nameof(monitor));
+    private readonly SeasonalDecayMultiplier _seasonalDecayMultiplier = seasonalDecayMultiplier ?? throw new ArgumentNullException(nameof(seasonalDecayMultiplier));
+
+    public void ProcessDayStart(string locationName)
+    {
+        if (locationName == "Greenhouse")
+        {
+            _monitor.Log("SoilDecay: Greenhouse exempt from decay.", LogLevel.Trace);
+            return;
+        }
+
+        var location = GetLocationByName(locationName);
+        if (location == null)
+        {
+            _monitor.Log($"SoilDecay: Location '{locationName}' not found, skipping.", LogLevel.Trace);
+            return;
+        }
+
+        var season = Game1.currentSeason.ToLowerInvariant();
+        var multiplier = _seasonalDecayMultiplier.GetMultiplier(season);
+
+        if (multiplier == 0f)
+        {
+            _monitor.Log($"SoilDecay: Winter - no decay for {locationName}.", LogLevel.Trace);
+            return;
+        }
+
+        var decayAmount = ModConstants.DailyDecayRate * multiplier;
+        int tilesProcessed = 0;
+        float totalHealthLost = 0f;
+
+        foreach (var kvp in location.terrainFeatures.Pairs)
+        {
+            if (kvp.Value is HoeDirt hoeDirt)
+            {
+                bool isBare = hoeDirt.crop == null;
+                if (isBare)
+                {
+                    var tile = kvp.Key;
+                    var currentHealth = _soilHealthService.GetSoilHealth(locationName, tile);
+                    var newHealth = Math.Max(currentHealth - decayAmount, 0f);
+                    _soilHealthService.UpdateHealth(locationName, tile, -decayAmount);
+                    totalHealthLost += (currentHealth - newHealth);
+                    tilesProcessed++;
+                }
+            }
+        }
+
+        _monitor.Log($"SoilDecay: Processed {tilesProcessed} bare tiles in {locationName}, " +
+                     $"total health lost: {totalHealthLost:F1}, season: {season}, " +
+                     $"multiplier: {multiplier}, decayAmount: {decayAmount:F1}",
+                     LogLevel.Trace);
+    }
+
+    private static GameLocation? GetLocationByName(string locationName)
+    {
+        foreach (var loc in Game1.locations)
+        {
+            if (loc.Name == locationName)
+                return loc;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

Adds SoilDecayService that processes all tilled tiles at day start, applying seasonal-multiplied decay to bare tiles. Dead crop residue acts as mulch protection.

## Changes

-  — Decay calculation with Greenhouse exemption
- Domain foundation files (interfaces, models, constants from PR 1)

## Story position

PR 2 of 4 for 002-soil-decay-compost.

## Build status

Builds cleanly on its own. Service is not yet wired into ModController (PR 4).