### PR TITLE
docs(agents): add layered AGENTS.md for LivingRoots, Controllers, Domain, Services (PR 2/3)

### DIFF
--- a/LivingRoots/AGENTS.md
+++ b/LivingRoots/AGENTS.md
@@ -1,0 +1,50 @@
+# LIVINGROOTS PROJECT
+
+**OVERVIEW:** SMAPI mod composition root — wires domain interfaces to service implementations and orchestrates game events.
+
+## STRUCTURE
+
+```
+ModEntry.cs              # Primary composition root (only `new` site for services)
+ModConstants.cs          # All magic numbers — costs, durations, limits
+AssemblyInfo.cs          # InternalsVisibleTo("LivingRoots.Tests")
+Controllers/
+  ModController.cs       # Event orchestrator (atomic state machine, ~1k LOC)
+  CompostingBinController.cs  # Right-click bin interaction
+Domain/
+  Interfaces/            # 14 service contracts (ISoilHealthService, etc.)
+  Models/                # Persistence DTOs (SoilHealthState, CompostingBinData)
+  Services/              # Pure domain logic (OrganicWasteValidator, SeasonalDecayMultiplier)
+  Visualization/         # Color/health DTOs, categories, overlay types
+Services/
+  *.cs                   # Application services (SoilHealthService, CompostingBinService, etc.)
+  Visualization/         # XNA renderers: overlays, tooltips, hoe feedback
+```
+
+## WHERE TO LOOK
+
+| Task | File |
+|------|------|
+| Wire new dependency | `ModEntry.cs` — constructor-injection site |
+| Add game event | `ModController.cs` — use `ExecuteWithConcurrencyGuard` for re-entrancy |
+| Change magic numbers | `ModConstants.cs` — single source of truth |
+| Add domain concept | `Domain/Interfaces/` (contract) + `Services/` (impl) |
+| Add rendering effect | `Services/Visualization/` — implement `IVisualizationService` |
+| Thread-safe state | `ModController.cs` — atomic bit flags on `_state` field |
+
+## CONVENTIONS
+
+- **DDD layering:** Contract in `Domain/Interfaces/`, impl in `Services/` — never invert
+- **Constructor injection only** — `ModEntry.cs` is the sole composition root
+- **Atomic state machine:** `_state` uses bit flags; mutate via `Interlocked.CompareExchange`
+- **Primary constructors** — C# 12 `params` syntax on controllers
+- **No expression-bodied members** — editorconfig `csharp_style_expression_bodied_methods = false`
+- **DDD language:** `SoilHealth`, `Compost`, `LivingSoil`, `HeirloomSeed`, `CompanionPlanting`
+
+## ANTI-PATTERNS
+
+- **DO NOT** `new` services outside `ModEntry.cs` — breaks DI pattern
+- **DO NOT** mutate `_state` without `Interlocked` — races with event unsubscription
+- **DO NOT** implement domain logic in `Controllers/` — use `Domain/Services/` or `Services/`
+- **DO NOT** use expression-bodied methods — violates editorconfig and root convention
+- **DO NOT** suppress overflow — `CheckForOverflowUnderflow=true` project-wide

--- a/LivingRoots/Controllers/AGENTS.md
+++ b/LivingRoots/Controllers/AGENTS.md
@@ -1,0 +1,24 @@
+# CONTROLLERS
+
+SMAPI event handlers. Thread-safe orchestration layer between game events and domain services.
+
+## Files
+
+| File | Role |
+|------|------|
+| `ModController.cs` | Main orchestrator: GameLaunched, SaveLoaded, Saving, RenderedWorld, ButtonReleased, UpdateTicked. Atomic flag state machine with rollback. |
+| `CompostingBinController.cs` | Handles composting bin interactions (ButtonPressed). |
+
+## Conventions
+
+- **Re-entrancy protection**: All event handlers must use `ExecuteWithConcurrencyGuard(flag, name, action)` — never call handler logic directly.
+- **Atomic state flags**: Use `Interlocked` operations on `_state` (`EventsRegisteredFlag`, `CommandRegisteredFlag`, `DisposedFlag`, `RegisteringFlag`, `UnregisteringFlag`, `OnSaveLoadedExecutingFlag`, `OnSavingExecutingFlag`). Never read/write `_state` directly without `Volatile.Read`/`Interlocked`.
+- **Console commands**: Register via `_helper.ConsoleCommands.Add()` inside `lock (_commandLock)` with `CommandRegisteredFlag` deduplication.
+- **Visualization events**: Only subscribe to `RenderedWorld`, `ButtonReleased`, `UpdateTicked` when `_visualizationService != null`.
+- **Rollback**: If any unsubscription fails, re-subscribe successfully removed handlers (all-or-nothing). Implemented in `ExecuteRollback`.
+
+## Anti-Patterns
+
+- DO NOT subscribe to events outside of `RegisterEvents()`.
+- DO NOT access disposed dependencies without null checks — always use `IsDisposed()` or null-conditional operators.
+- DO NOT expose raw exception messages in logs — log `ex.GetType().FullName` and `HResult` at `LogLevel.Trace` only.

--- a/LivingRoots/Domain/AGENTS.md
+++ b/LivingRoots/Domain/AGENTS.md
@@ -1,0 +1,36 @@
+# DOMAIN LAYER
+
+Pure business logic — no SMAPI dependencies. Game types (`StardewValley.*`, `Microsoft.Xna.Framework.*`) are permitted; SMAPI using statements are forbidden.
+
+## Structure
+
+| Folder | Contents |
+|--------|----------|
+| `Interfaces/` | Service contracts — `ICompostingBinService`, `ICompostApplicationService`, `ISoilDecayService`, `IOrganicWasteValidator`, `IVisualizationService` |
+| `Models/` | Persistence DTOs — `SoilHealthState`, `CompostingBinData`, `CompostingBinStateModel` |
+| `Services/` | Domain services (stateless business rules) — `OrganicWasteValidator`, `SeasonalDecayMultiplier` |
+| `Visualization/` | Render DTOs — `ColorDTO`, `ColorMapping`, `HealthCategory`, `TileOverlay`, `TooltipData`, `HoeFeedback`, `VisualizationConfiguration` |
+
+## Interface Roles
+
+- `ICompostingBinService` — State machine for bins (Empty→Processing→Ready); handles waste input, collection, maturation, day-start transitions
+- `ICompostApplicationService` — Validates tile state and applies compost to tilled soil
+- `ISoilDecayService` — Daily decay for bare tilled tiles; exempts Greenhouse, respects dead-crop mulch
+- `IOrganicWasteValidator` — Hybrid: inclusion tag `compostable_item` OR vanilla category IDs (-74, -75, -79, -80, -81); exclusion tag `not_compostable` overrides all
+
+## Domain vs Application Services
+
+- **Domain services** (in `Domain/Services/`): Pure business rules — validation, seasonal multipliers, computations. No side effects.
+- **Application services** (in `LivingRoots/Services/`): Implement Domain interfaces. Handle SMAPI, persistence, game event orchestration.
+
+## Key Values
+
+- `CompostingBinState`: `Empty=0`, `Processing=1`, `Ready=2`
+- `HealthCategory` half-open intervals: Poor [0,34), Moderate [34,67), Healthy [67,100]
+- `SeasonalDecayMultiplier`: Spring 0.5x, Summer 1.5x, Fall 0.5x, Winter 0.0x
+
+## Anti-Patterns
+
+- DO NOT add SMAPI using statements — this layer is framework-agnostic
+- DO NOT implement persistence logic here — defer to LivingRoots/Services/
+- DO NOT hardcode game values — reference ModConstants

--- a/LivingRoots/Services/AGENTS.md
+++ b/LivingRoots/Services/AGENTS.md
@@ -1,0 +1,35 @@
+# SERVICES
+
+Application services — implement domain interfaces, integrate with SMAPI, manage persistence.
+
+## FILES
+
+| File | Purpose |
+|------|---------|
+| `SoilHealthService.cs` | Load/save/query soil health. Runtime cache: `Dictionary<string, Dictionary<Point, float>>`. Sparse cache (no zero values). DoS protection via tile limits. Snapshot-outside-lock. |
+| `CompostingBinService.cs` | State machine: Empty → Processing → Ready. Validates organic waste via `IOrganicWasteValidator`. |
+| `CompostApplicationService.cs` | Apply compost to tiles. Validates farm/Greenhouse, HoeDirt terrain, health cap, held item. |
+| `SoilDecayService.cs` | Daily decay at day start. Uses `SeasonalDecayMultiplier` domain service. Greenhouse exempt. |
+| `ModDataService.cs` | SMAPI data persistence. Path sanitization, TOCTOU race prevention, no raw exception messages in logs. |
+| `PathTraversalValidator.cs` | Adapter → domain `IPathValidationService` |
+| `UnicodeNormalizer.cs` | Adapter → domain `IUnicodeNormalizationService` |
+| `FileNameSanitizer.cs` | Adapter → domain `IFileNameSanitizationService` |
+| `SaveIdProvider.cs` | Abstraction over `Constants.SaveFolderName` with length validation. |
+| `CompostingBinFactory.cs` | Creates `CompostingBinStateModel` instances with default state. |
+
+## CONVENTIONS
+
+- **Adapter pattern**: Security validators delegate to domain services — no duplicated logic.
+- **Constructor injection** for all services.
+- **Sparse cache**: `SoilHealthService` omits zero/default health values to keep saves small.
+- **Snapshot outside lock**: Capture data, release lock, then perform I/O.
+- **Fail-fast**: Return `null` for expected failures (invalid saveId, sanitization failure); don't throw.
+- **Data key format**: `"data/{sanitizedKey}.json"` via `IModHelper.Data`.
+- **Log security**: Generic messages only — never embed raw exception content.
+
+## ANTI-PATTERNS
+
+- DO NOT use `.Result` or `.Wait()` on async calls.
+- DO NOT hold lock during I/O operations.
+- DO NOT expose raw exception messages in logs.
+- DO NOT create files outside SMAPI data API.


### PR DESCRIPTION
## Summary
Add per-layer AGENTS.md files for the four main project directories. Each file captures layer-specific conventions, file purposes, and anti-patterns without duplicating the root knowledge base.

## Changes
- `LivingRoots/AGENTS.md`: 50 lines — project structure, composition root, conventions
- `LivingRoots/Controllers/AGENTS.md`: 24 lines — atomic state machine, rollback, thread safety
- `LivingRoots/Domain/AGENTS.md`: 36 lines — interfaces, models, ubiquitous language, no-SMAPI rule
- `LivingRoots/Services/AGENTS.md`: 35 lines — application services, persistence, fail-fast conventions

## Story position
PR 2 of 3 for `docs/003`. Builds on the root knowledge file by documenting each architectural layer.

## Build status
Adds documentation only — no code changes.
