### PR TITLE
feat(003): update existing tests for new constructor (PR 6/6)

### DIFF
--- a/LivingRoots.Tests/ConcurrentRegisterUnregisterRaceConditionTest.cs
+++ b/LivingRoots.Tests/ConcurrentRegisterUnregisterRaceConditionTest.cs
@@ -43,7 +43,8 @@ namespace LivingRoots.Tests
 
             // Create a single ModController instance to be shared across all tasks
             var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object,
-                _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+                _mockSoilHealthService.Object, _mockSaveIdProvider.Object,
+                new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // First register events to set up the controller with handlers
             controller.RegisterEvents();
@@ -142,7 +143,8 @@ namespace LivingRoots.Tests
 
             // Create a single ModController instance to be shared across all tasks
             var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object,
-                _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+                _mockSoilHealthService.Object, _mockSaveIdProvider.Object,
+                new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // First register events to set up the controller with handlers
             controller.RegisterEvents();

--- a/LivingRoots.Tests/ModControllerTests.cs
+++ b/LivingRoots.Tests/ModControllerTests.cs
@@ -38,31 +38,31 @@ namespace LivingRoots.Tests
         [Fact]
         public void Constructor_WithNullHelper_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new ModController(null!, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object));
+            Assert.Throws<ArgumentNullException>(() => new ModController(null!, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object));
         }
 
         [Fact]
         public void Constructor_WithNullMonitor_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, null!, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object));
+            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, null!, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object));
         }
 
         [Fact]
         public void Constructor_WithNullManifest_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, _mockMonitor.Object, null!, _mockSoilHealthService.Object, _mockSaveIdProvider.Object));
+            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, _mockMonitor.Object, null!, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object));
         }
 
         [Fact]
         public void Constructor_WithNullSoilHealthService_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, null!, _mockSaveIdProvider.Object));
+            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, null!, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object));
         }
 
         [Fact]
         public void Constructor_WithNullSaveIdProvider_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, null!));
+            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, null!, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object));
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace LivingRoots.Tests
             mockEvents.Setup(x => x.GameLoop).Returns(mockGameLoopEvents.Object);
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Act & Assert - Should not throw when controller is properly constructed
             var ex = Record.Exception(() => controller.RegisterEvents());
@@ -93,7 +93,7 @@ namespace LivingRoots.Tests
             _mockHelper.Setup(x => x.Events).Returns((IModEvents)null!); // Return null for Events
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Act & Assert - Should not throw when Events is null
             var ex = Record.Exception(() => controller.RegisterEvents());
@@ -111,7 +111,7 @@ namespace LivingRoots.Tests
             mockEvents.Setup(x => x.GameLoop).Returns((IGameLoopEvents)null!); // Return null for GameLoop
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Act & Assert - Should not throw when GameLoop is null
             var ex = Record.Exception(() => controller.RegisterEvents());
@@ -131,7 +131,7 @@ namespace LivingRoots.Tests
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
             // Create a single ModController instance to be shared across all tasks
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Act - Simulate concurrent registration attempts on the same instance
             var tasks = new List<System.Threading.Tasks.Task>();
@@ -171,7 +171,7 @@ namespace LivingRoots.Tests
                 .SetupAdd(x => x.GameLaunched += It.IsAny<EventHandler<GameLaunchedEventArgs>>())
                 .Throws(new Exception("Test exception"));
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Act & Assert - Should handle exception gracefully and not propagate
             var ex = Record.Exception(() => controller.RegisterEvents());
@@ -199,7 +199,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupRemove(x => x.SaveLoaded -= It.IsAny<EventHandler<SaveLoadedEventArgs>>());
             mockGameLoopEvents.SetupRemove(x => x.Saving -= It.IsAny<EventHandler<SavingEventArgs>>());
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // First register events to set up the controller
             controller.RegisterEvents();
@@ -225,7 +225,7 @@ namespace LivingRoots.Tests
             mockEvents.Setup(x => x.GameLoop).Returns(mockGameLoopEvents.Object);
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Act
             controller.UnregisterEvents();
@@ -249,7 +249,7 @@ namespace LivingRoots.Tests
             mockEvents.Setup(x => x.GameLoop).Returns(threadSafeGameLoopEvents);
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // First register events to set up the controller
             controller.RegisterEvents();
@@ -296,7 +296,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupRemove(x => x.SaveLoaded -= It.IsAny<EventHandler<SaveLoadedEventArgs>>());
             mockGameLoopEvents.SetupRemove(x => x.Saving -= It.IsAny<EventHandler<SavingEventArgs>>());
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // First register events to initialize the controller
             controller.RegisterEvents();
@@ -335,7 +335,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupRemove(x => x.SaveLoaded -= It.IsAny<EventHandler<SaveLoadedEventArgs>>());
             mockGameLoopEvents.SetupRemove(x => x.Saving -= It.IsAny<EventHandler<SavingEventArgs>>());
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // First register events to initialize the controller
             controller.RegisterEvents();
@@ -370,7 +370,7 @@ namespace LivingRoots.Tests
             mockEvents.Setup(x => x.GameLoop).Returns(mockGameLoopEvents.Object);
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events first to initialize the command registration
             controller.RegisterEvents();
@@ -394,7 +394,7 @@ namespace LivingRoots.Tests
             mockEvents.Setup(x => x.GameLoop).Returns(mockGameLoopEvents.Object);
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events first to initialize the command registration
             controller.RegisterEvents();
@@ -429,7 +429,7 @@ namespace LivingRoots.Tests
             mockEvents.Setup(x => x.GameLoop).Returns(mockGameLoopEvents.Object);
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events first to initialize the command registration
             controller.RegisterEvents();
@@ -467,7 +467,7 @@ namespace LivingRoots.Tests
             // Mock the save ID provider to return a valid save ID
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns("test_save_id");
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events to ensure proper setup before calling OnSaveLoaded
             controller.RegisterEvents();
@@ -494,7 +494,7 @@ namespace LivingRoots.Tests
             // Mock the save ID provider to return a valid save ID
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns("test_save_id");
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events to ensure proper setup before calling OnSaving
             controller.RegisterEvents();
@@ -519,7 +519,7 @@ namespace LivingRoots.Tests
             _mockHelper.Setup(x => x.Events).Returns(mockEvents.Object);
             mockEvents.Setup(x => x.GameLoop).Returns(mockGameLoopEvents.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Act & Assert - Initially should not be disposed
             // Verify that controller can be used before disposal
@@ -552,7 +552,7 @@ namespace LivingRoots.Tests
         public void TrySetStateFlag_SetsFlagAtomically()
         {
             // Arrange
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
             const int testFlag = ModController.EventsRegisteredFlag;
 
             // Act
@@ -584,7 +584,7 @@ namespace LivingRoots.Tests
             mockEvents.Setup(x => x.GameLoop).Returns(mockGameLoopEvents.Object);
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Act - Dispose the controller
             controller.Dispose();
@@ -614,7 +614,7 @@ namespace LivingRoots.Tests
             // Mock SaveIdProvider to return null (simulating unavailable save folder)
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns((string?)null);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events to ensure proper setup
             controller.RegisterEvents();
@@ -643,7 +643,7 @@ namespace LivingRoots.Tests
             // Mock SaveIdProvider to return null (simulating unavailable save folder)
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns((string?)null);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events to ensure proper setup
             controller.RegisterEvents();
@@ -682,7 +682,7 @@ namespace LivingRoots.Tests
             const string expectedSaveId = "test_save_12345";
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns(expectedSaveId);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events to ensure proper setup before triggering SaveLoaded
             controller.RegisterEvents();
@@ -724,7 +724,7 @@ namespace LivingRoots.Tests
             const string expectedSaveId = "test_save_67890";
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns(expectedSaveId);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events to ensure proper setup before triggering Saving
             controller.RegisterEvents();
@@ -767,7 +767,7 @@ namespace LivingRoots.Tests
             const string expectedSaveId = "test_save_complete_flow";
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns(expectedSaveId);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events to ensure proper setup
             controller.RegisterEvents();
@@ -810,7 +810,7 @@ namespace LivingRoots.Tests
             // Mock SaveIdProvider to return null (simulating unavailable save folder)
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns((string?)null);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events to ensure proper setup
             controller.RegisterEvents();
@@ -850,7 +850,7 @@ namespace LivingRoots.Tests
             // Mock SaveIdProvider to return empty string (simulating unavailable save folder)
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns(string.Empty);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events to ensure proper setup
             controller.RegisterEvents();
@@ -891,7 +891,7 @@ namespace LivingRoots.Tests
             const string complexSaveId = "Save_2024-01-15_FarmerName_123";
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns(complexSaveId);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events to ensure proper setup
             controller.RegisterEvents();
@@ -932,7 +932,7 @@ namespace LivingRoots.Tests
             const string expectedSaveId = "test_save_multiple";
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns(expectedSaveId);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events to ensure proper setup
             controller.RegisterEvents();
@@ -972,7 +972,7 @@ namespace LivingRoots.Tests
             const string expectedSaveId = "test_save_multiple_saves";
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns(expectedSaveId);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events to ensure proper setup
             controller.RegisterEvents();

--- a/LivingRoots.Tests/ModEntryTests.cs
+++ b/LivingRoots.Tests/ModEntryTests.cs
@@ -72,7 +72,9 @@ namespace LivingRoots.Tests
                 mockMonitor.Object,
                 mockManifest.Object,
                 mockSoilHealthService.Object,
-                mockSaveIdProvider.Object);
+                mockSaveIdProvider.Object,
+                new Mock<ICompostingBinService>().Object,
+                new Mock<ISoilDecayService>().Object);
 
             // Set the controller field directly using reflection
             var controllerField = typeof(ModEntry).GetField("_controller", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -109,7 +111,9 @@ namespace LivingRoots.Tests
                 mockMonitor.Object,
                 mockManifest.Object,
                 mockSoilHealthService.Object,
-                mockSaveIdProvider.Object);
+                mockSaveIdProvider.Object,
+                new Mock<ICompostingBinService>().Object,
+                new Mock<ISoilDecayService>().Object);
 
             // Set the controller field directly using reflection
             var controllerField = typeof(ModEntry).GetField("_controller", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -145,7 +149,9 @@ namespace LivingRoots.Tests
                 mockMonitor.Object,
                 mockManifest.Object,
                 mockSoilHealthService.Object,
-                mockSaveIdProvider.Object);
+                mockSaveIdProvider.Object,
+                new Mock<ICompostingBinService>().Object,
+                new Mock<ISoilDecayService>().Object);
 
             // Set the controller field directly using reflection
             var controllerField = typeof(ModEntry).GetField("_controller", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -216,7 +222,9 @@ namespace LivingRoots.Tests
                 mockMonitor.Object,
                 mockManifest.Object,
                 mockSoilHealthService.Object,
-                mockSaveIdProvider.Object);
+                mockSaveIdProvider.Object,
+                new Mock<ICompostingBinService>().Object,
+                new Mock<ISoilDecayService>().Object);
 
             // Set the controller field directly using reflection
             var controllerField = typeof(ModEntry).GetField("_controller", BindingFlags.NonPublic | BindingFlags.Instance);

--- a/LivingRoots.Tests/RegisterEventsRaceConditionTest.cs
+++ b/LivingRoots.Tests/RegisterEventsRaceConditionTest.cs
@@ -43,7 +43,7 @@ namespace LivingRoots.Tests
 
             // Create a single ModController instance to be shared across all tasks
             var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object,
-                _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+                _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // First register events to set up the controller with handlers
             controller.RegisterEvents();
@@ -131,7 +131,7 @@ namespace LivingRoots.Tests
 
             // Create a single ModController instance to be shared across all tasks
             var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object,
-                _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+                _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Act: Simulate multiple concurrent registration attempts
             // This should reveal the race condition where multiple threads pass the

--- a/LivingRoots.Tests/UnregisterEventsDuringDisposalTests.cs
+++ b/LivingRoots.Tests/UnregisterEventsDuringDisposalTests.cs
@@ -73,7 +73,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupAdd(x => x.Saving += It.IsAny<EventHandler<SavingEventArgs>>())
                 .Callback<EventHandler<SavingEventArgs>>(h => { });
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events first to set up the controller
             controller.RegisterEvents();
@@ -138,7 +138,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupAdd(x => x.Saving += It.IsAny<EventHandler<SavingEventArgs>>())
                 .Callback<EventHandler<SavingEventArgs>>(h => { });
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events first to set up the controller
             controller.RegisterEvents();
@@ -204,7 +204,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupAdd(x => x.Saving += It.IsAny<EventHandler<SavingEventArgs>>())
                 .Callback<EventHandler<SavingEventArgs>>(h => { });
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events first to set up the controller
             controller.RegisterEvents();

--- a/LivingRoots.Tests/UnregisterEventsRollbackTests.cs
+++ b/LivingRoots.Tests/UnregisterEventsRollbackTests.cs
@@ -88,7 +88,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupRemove(x => x.Saving -= It.IsAny<EventHandler<SavingEventArgs>>())
                 .Callback<EventHandler<SavingEventArgs>>(h => { });
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events first to set up the controller
             controller.RegisterEvents();
@@ -143,7 +143,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupRemove(x => x.Saving -= It.IsAny<EventHandler<SavingEventArgs>>())
                 .Throws(new InvalidOperationException("Saving unsubscribe failed"));
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events first to set up the controller
             controller.RegisterEvents();
@@ -197,7 +197,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupRemove(x => x.Saving -= It.IsAny<EventHandler<SavingEventArgs>>())
                 .Callback<EventHandler<SavingEventArgs>>(h => { });
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events first to set up the controller
             controller.RegisterEvents();
@@ -249,7 +249,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupRemove(x => x.Saving -= It.IsAny<EventHandler<SavingEventArgs>>())
                 .Callback<EventHandler<SavingEventArgs>>(h => { });
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, new Mock<ICompostingBinService>().Object, new Mock<ISoilDecayService>().Object);
 
             // Register events first to set up the controller
             controller.RegisterEvents();

--- a/LivingRoots.Tests/Visualization/ModControllerVisualizationTests.cs
+++ b/LivingRoots.Tests/Visualization/ModControllerVisualizationTests.cs
@@ -28,6 +28,8 @@ namespace LivingRoots.Tests.Visualization
             var controller = new Controllers.ModController(
                 mockHelper.Object, mockMonitor.Object, mockManifest.Object,
                 mockSoilService.Object, mockSaveIdProvider.Object,
+                new Mock<ICompostingBinService>().Object,
+                new Mock<ISoilDecayService>().Object,
                 mockVisService.Object, mockConfigService.Object);
         }
     }


### PR DESCRIPTION
## Summary
Update existing test files to pass the new ICompostingBinService and ISoilDecayService parameters to ModController constructor.

## Files Updated
- ModControllerTests
- ModEntryTests
- UnregisterEventsRollbackTests
- UnregisterEventsDuringDisposalTests
- RegisterEventsRaceConditionTest
- ConcurrentRegisterUnregisterRaceConditionTest
- ModControllerVisualizationTests

## Story position
PR 6 of 6 for feature 003-composting-tests.