### PR TITLE
feat(services): add production implementations for extracted interfaces (PR 3/6)

### DIFF
--- a/LivingRoots/Services/PlayerProvider.cs
+++ b/LivingRoots/Services/PlayerProvider.cs
@@ -1,0 +1,16 @@
+using LivingRoots.Domain;
+using StardewValley;
+
+namespace LivingRoots.Services;
+
+/// <summary>
+/// Production implementation of <see cref="IPlayerProvider"/> that wraps <see cref="Game1"/>.
+/// </summary>
+public class PlayerProvider : IPlayerProvider
+{
+    /// <inheritdoc />
+    public Farmer CurrentPlayer => Game1.player;
+
+    /// <inheritdoc />
+    public Item? CurrentItem => Game1.player?.CurrentItem;
+}

--- a/LivingRoots/Services/SeasonProvider.cs
+++ b/LivingRoots/Services/SeasonProvider.cs
@@ -1,0 +1,15 @@
+using LivingRoots.Domain;
+using StardewValley;
+
+namespace LivingRoots.Services;
+
+/// <summary>
+/// Production implementation of <see cref="ISeasonProvider"/> that wraps <see cref="Game1.currentSeason"/>.
+/// </summary>
+public class SeasonProvider : ISeasonProvider
+{
+    /// <summary>
+    /// Gets the current season name from the game state.
+    /// </summary>
+    public string CurrentSeason => Game1.currentSeason;
+}

--- a/LivingRoots/Services/TimeProvider.cs
+++ b/LivingRoots/Services/TimeProvider.cs
@@ -1,0 +1,16 @@
+using LivingRoots.Domain;
+using StardewValley;
+
+namespace LivingRoots.Services;
+
+/// <summary>
+/// Production implementation of <see cref="ITimeProvider"/>
+/// that wraps <see cref="Game1.Date.TotalDays"/>.
+/// </summary>
+public class TimeProvider : ITimeProvider
+{
+    /// <summary>
+    /// Gets the total number of days elapsed in the current save.
+    /// </summary>
+    public int TotalDays => Game1.Date.TotalDays;
+}


### PR DESCRIPTION
## Summary
Adds the production (runtime) implementations of the three interfaces
extracted in PR 2. Each provider wraps the corresponding Game1 static
access and is registered as a singleton in the composition root.

## Changes
- `LivingRoots/Services/TimeProvider.cs`: Production impl of ITimeProvider (reads Game1.Date)
- `LivingRoots/Services/SeasonProvider.cs`: Production impl of ISeasonProvider (reads Game1.currentSeason)
- `LivingRoots/Services/PlayerProvider.cs`: Production impl of IPlayerProvider (reads Game1.player)

## Story position
PR 3 of 6 for `003-composting-tests". This PR lands the production implementations. The next PR will apply prerequisite fixes to existing services and models.