### PR TITLE
test(infra): add test stubs and fixtures for deterministic testing (PR 5/6)

### DIFF
--- a/LivingRoots.Tests/Fixtures/GameLocationFixture.cs
+++ b/LivingRoots.Tests/Fixtures/GameLocationFixture.cs
@@ -1,0 +1,20 @@
+using Microsoft.Xna.Framework;
+using StardewValley;
+using StardewValley.TerrainFeatures;
+
+namespace LivingRoots.Tests.Fixtures
+{
+    public static class GameLocationFixture
+    {
+        public static GameLocation CreateLocation(string mapPath = "Maps\\Farm", string name = "Farm")
+        {
+            return new GameLocation(mapPath, name);
+        }
+
+        public static void AddHoeDirtTile(GameLocation location, Vector2 tile, int seed = 0)
+        {
+            var hoeDirt = new HoeDirt(seed, location);
+            location.terrainFeatures.Add(tile, hoeDirt);
+        }
+    }
+}

--- a/LivingRoots.Tests/Fixtures/ItemFactory.cs
+++ b/LivingRoots.Tests/Fixtures/ItemFactory.cs
@@ -1,0 +1,28 @@
+using StardewValley;
+
+namespace LivingRoots.Tests.Fixtures
+{
+    public static class ItemFactory
+    {
+        public static Item CreateValidWasteItem()
+        {
+            var item = new StardewValley.Object("Seeds", 1);
+            item.Category = -74;
+            return item;
+        }
+
+        public static Item CreateInvalidWasteItem()
+        {
+            var item = new StardewValley.Object("Stone", 1);
+            item.Category = -12;
+            return item;
+        }
+
+        public static Item CreateItem(string qualifiedItemId, int category)
+        {
+            var item = new StardewValley.Object(qualifiedItemId, 1);
+            item.Category = category;
+            return item;
+        }
+    }
+}

--- a/LivingRoots.Tests/Stubs/PlayerProviderStub.cs
+++ b/LivingRoots.Tests/Stubs/PlayerProviderStub.cs
@@ -1,0 +1,12 @@
+using StardewValley;
+
+using LivingRoots.Domain;
+
+namespace LivingRoots.Tests.Stubs
+{
+    public class PlayerProviderStub : IPlayerProvider
+    {
+        public Farmer CurrentPlayer { get; set; } = null!;
+        public Item? CurrentItem { get; set; }
+    }
+}

--- a/LivingRoots.Tests/Stubs/SeasonProviderStub.cs
+++ b/LivingRoots.Tests/Stubs/SeasonProviderStub.cs
@@ -1,0 +1,17 @@
+using LivingRoots.Domain;
+
+namespace LivingRoots.Tests.Stubs
+{
+    /// <summary>
+    /// Stub implementation of <see cref="ISeasonProvider"/> for unit testing.
+    /// Provides a settable <see cref="CurrentSeason"/> so tests can control the simulated season.
+    /// </summary>
+    public class SeasonProviderStub : ISeasonProvider
+    {
+        /// <summary>
+        /// Gets or sets the current season name.
+        /// Defaults to "spring".
+        /// </summary>
+        public string CurrentSeason { get; set; } = "spring";
+    }
+}

--- a/LivingRoots.Tests/Stubs/TimeProviderStub.cs
+++ b/LivingRoots.Tests/Stubs/TimeProviderStub.cs
@@ -1,0 +1,17 @@
+using LivingRoots.Domain;
+
+namespace LivingRoots.Tests.Stubs
+{
+    /// <summary>
+    /// Stub implementation of <see cref="ITimeProvider"/> for unit testing.
+    /// Provides a settable <see cref="TotalDays"/> so tests can control the simulated day count.
+    /// </summary>
+    public class TimeProviderStub : ITimeProvider
+    {
+        /// <summary>
+        /// Gets or sets the total number of days elapsed in the simulated save.
+        /// Defaults to 1 (first day of the game).
+        /// </summary>
+        public int TotalDays { get; set; } = 1;
+    }
+}


### PR DESCRIPTION
## Summary
Adds the test infrastructure layer: deterministic stubs for the three
extracted interfaces and shared fixtures for game location and item
creation. These are the building blocks that all test files (PR 6) depend on.

## Changes
- `LivingRoots.Tests/Stubs/TimeProviderStub.cs`: Deterministic ITimeProvider stub
- `LivingRoots.Tests/Stubs/SeasonProviderStub.cs`: Deterministic ISeasonProvider stub
- `LivingRoots.Tests/Stubs/PlayerProviderStub.cs`: Deterministic IPlayerProvider stub
- `LivingRoots.Tests/Fixtures/GameLocationFixture.cs`: Configurable GameLocation for tile iteration
- `LivingRoots.Tests/Fixtures/ItemFactory.cs`: Factory for creating test items

## Story position
PR 5 of 6 for `003-composting-tests". This PR adds test infrastructure. The next PR will add the actual test files.