### PR TITLE
docs(spec): land composting test docs — research, data model, contracts (PR 1/3)

### DIFF
--- a/specs/003-composting-tests/contracts/test-fixtures.md
+++ b/specs/003-composting-tests/contracts/test-fixtures.md
@@ -1,0 +1,542 @@
+# Test Fixture Contracts
+
+**Date**: 2026-09-07
+**Feature**: Composting State Machine Tests (`specs/003-composting-tests/`)
+
+## Overview
+
+This document defines the test fixture contracts and helper patterns for the composting test suite. These contracts ensure consistency across test files and provide reusable patterns for common testing scenarios. All time/season/player dependencies use stub implementations of the extracted interfaces (`ITimeProvider`, `ISeasonProvider`, `IPlayerProvider`).
+
+---
+
+## Contract 1: TimeProviderStub
+
+### Purpose
+Stub implementation of `ITimeProvider` for time-dependent tests. Replaces direct `Game1.Date.TotalDays` access.
+
+### Interface
+
+```csharp
+public class TimeProviderStub : ITimeProvider
+{
+    public int TotalDays { get; set; } = 1;
+}
+```
+
+### Behavior
+- **TotalDays**: Settable property to control the current day in tests
+- No dependencies on `Game1` or any game state
+
+### Usage
+
+```csharp
+[Fact]
+public void ProcessDayStart_AfterTwoDays_TransitionsToReady()
+{
+    var timeStub = new TimeProviderStub { TotalDays = 1 };
+    var fixture = new CompostingBinFixture(timeStub);
+    fixture.Service.AddWaste("Farm", new Vector2(10, 10), validItem);
+    
+    timeStub.TotalDays = 3;
+    fixture.Service.ProcessDayStart("Farm");
+    
+    Assert.Equal(CompostingBinState.Ready, 
+        fixture.Service.GetBinState("Farm", new Vector2(10, 10)));
+}
+```
+
+### Guarantees
+- No `Game1` dependency — works in pure unit test context
+- Thread-safe for single-threaded test execution
+- Deterministic — value only changes when test sets it
+
+---
+
+## Contract 2: SeasonProviderStub
+
+### Purpose
+Stub implementation of `ISeasonProvider` for season-dependent tests. Replaces direct `Game1.currentSeason` access.
+
+### Interface
+
+```csharp
+public class SeasonProviderStub : ISeasonProvider
+{
+    public string CurrentSeason { get; set; } = "spring";
+}
+```
+
+### Behavior
+- **CurrentSeason**: Settable property to control the current season in tests
+- No dependencies on `Game1` or any game state
+
+### Usage
+
+```csharp
+[Fact]
+public void ProcessDayStart_SummerDecay_HigherThanSpring()
+{
+    var springStub = new SeasonProviderStub { CurrentSeason = "spring" };
+    var summerStub = new SeasonProviderStub { CurrentSeason = "summer" };
+    // ... test both and compare decay amounts
+}
+```
+
+### Guarantees
+- No `Game1` dependency — works in pure unit test context
+- Deterministic — value only changes when test sets it
+
+---
+
+## Contract 3: PlayerProviderStub
+
+### Purpose
+Stub implementation of `IPlayerProvider` for player-dependent tests. Replaces direct `Game1.player` access.
+
+### Interface
+
+```csharp
+public class PlayerProviderStub : IPlayerProvider
+{
+    public Farmer CurrentPlayer { get; set; } = null!;
+    public Item? CurrentItem { get; set; }
+}
+```
+
+### Behavior
+- **CurrentPlayer**: Settable property to control the current player in tests
+- **CurrentItem**: Settable property to control the player's held item
+- No dependencies on `Game1` or any game state
+
+### Usage
+
+```csharp
+[Fact]
+public void TryApplyCompost_NoCompostHeld_ReturnsFalse()
+{
+    var playerStub = new PlayerProviderStub { CurrentItem = null };
+    var fixture = new CompostApplicationServiceFixture(playerStub);
+    
+    var result = fixture.Service.TryApplyCompost(location, new Vector2(10, 10));
+    
+    Assert.False(result);
+}
+```
+
+### Guarantees
+- No `Game1` dependency — works in pure unit test context
+- No player disposal semantics issues (unlike `Game1.player` setter)
+
+---
+
+## Contract 4: GameLocationFixture
+
+### Purpose
+Create real `GameLocation` instances with `HoeDirt` tiles for location-iteration tests.
+
+### Interface
+
+```csharp
+public class GameLocationFixture
+{
+    public GameLocation Location { get; }
+    public List<Vector2> TilledTiles { get; }
+    
+    public GameLocationFixture(string mapPath = "Maps\\Farm", string name = "Farm");
+    public void AddHoeDirtTile(int x, int y, bool bare = true);
+}
+```
+
+### Behavior
+- **Constructor**: Creates new `GameLocation` with given map path and name (correct signature: `GameLocation(string mapPath, string name)`)
+- **AddHoeDirtTile**: Adds a `HoeDirt` tile at specified coordinates
+  - `bare = true`: Tile has no crop (default)
+  - `bare = false`: Tile has a crop (for non-bare tests)
+
+### Usage
+
+```csharp
+[Fact]
+public void ProcessDayStart_BareTiles_DecaysHealth()
+{
+    var fixture = new GameLocationFixture("Maps\\Farm", "Farm");
+    fixture.AddHoeDirtTile(10, 10, bare: true);
+    fixture.AddHoeDirtTile(11, 10, bare: true);
+    
+    // Use fixture.Location in test...
+}
+```
+
+### Guarantees
+- Location is fully initialized with terrain features
+- Tilled tiles list tracks all added tiles for cleanup
+- Compatible with `SoilDecayService` location iteration
+- Uses correct constructor signature `GameLocation(string mapPath, string name)`
+
+---
+
+## Contract 5: CompostingBinFixture
+
+### Purpose
+Create `CompostingBinService` with mock dependencies for state machine tests.
+
+### Interface
+
+```csharp
+public class CompostingBinFixture
+{
+    public Mock<IModDataService> MockModDataService { get; }
+    public Mock<ISaveIdProvider> MockSaveIdProvider { get; }
+    public Mock<IOrganicWasteValidator> MockWasteValidator { get; }
+    public Mock<IMonitor> MockMonitor { get; }
+    public TimeProviderStub TimeStub { get; }
+    public CompostingBinFactory Factory { get; }
+    public CompostingBinService Service { get; }
+    
+    public CompostingBinFixture(TimeProviderStub? timeStub = null);
+}
+```
+
+### Behavior
+- **Constructor**: Creates all mock objects and injects into `CompostingBinService`
+- All mocks use default behavior (no setup required for basic tests)
+- `TimeStub` is settable for time-dependent tests
+- `Factory` is the real `CompostingBinFactory` (not mocked)
+- Service is ready to use immediately
+
+### Usage
+
+```csharp
+[Fact]
+public void AddWaste_ValidItem_TransitionsToProcessing()
+{
+    var fixture = new CompostingBinFixture();
+    var validItem = new Item { QualifiedItemId = "Object.Sap" };
+    fixture.MockWasteValidator.Setup(x => x.IsValidOrganicWaste(validItem)).Returns(true);
+    
+    fixture.Service.AddWaste("Farm", new Vector2(10, 10), validItem);
+    
+    Assert.Equal(CompostingBinState.Processing, 
+        fixture.Service.GetBinState("Farm", new Vector2(10, 10)));
+}
+```
+
+### Guarantees
+- All dependencies are mocked or stubbed
+- Service is isolated from external systems
+- Mocks are accessible for verification
+- TimeStub is accessible for time control
+
+---
+
+## Contract 6: CompostApplicationServiceFixture
+
+### Purpose
+Create `CompostApplicationService` with mock dependencies for compost application tests.
+
+### Interface
+
+```csharp
+public class CompostApplicationServiceFixture
+{
+    public Mock<ISoilHealthService> MockSoilHealthService { get; }
+    public Mock<IMonitor> MockMonitor { get; }
+    public PlayerProviderStub PlayerStub { get; }
+    public CompostApplicationService Service { get; }
+    
+    public CompostApplicationServiceFixture(PlayerProviderStub? playerStub = null);
+}
+```
+
+### Usage
+
+```csharp
+[Fact]
+public void TryApplyCompost_ValidTile_IncreasesHealth()
+{
+    var fixture = new CompostApplicationServiceFixture();
+    fixture.MockSoilHealthService.Setup(x => x.GetSoilHealth("Farm", new Vector2(10, 10))).Returns(50f);
+    
+    var location = new GameLocation("Maps\\Farm", "Farm");
+    var result = fixture.Service.TryApplyCompost(location, new Vector2(10, 10));
+    
+    Assert.True(result);
+    fixture.MockSoilHealthService.Verify(x => x.UpdateHealth("Farm", new Vector2(10, 10), ModConstants.RestorationAmount));
+}
+```
+
+---
+
+## Contract 7: SoilDecayServiceFixture
+
+### Purpose
+Create `SoilDecayService` with mock dependencies for decay calculation tests.
+
+### Interface
+
+```csharp
+public class SoilDecayServiceFixture
+{
+    public Mock<ISoilHealthService> MockSoilHealthService { get; }
+    public Mock<IMonitor> MockMonitor { get; }
+    public SeasonProviderStub SeasonStub { get; }
+    public SeasonalDecayMultiplier SeasonalMultiplier { get; }
+    public SoilDecayService Service { get; }
+    
+    public SoilDecayServiceFixture(SeasonProviderStub? seasonStub = null);
+}
+```
+
+### Usage
+
+```csharp
+[Fact]
+public void ProcessDayStart_BareTile_DecaysByDailyRate()
+{
+    var fixture = new SoilDecayServiceFixture();
+    var location = new GameLocation("Maps\\Farm", "Farm");
+    var tile = new Vector2(10, 10);
+    var hoeDirt = new HoeDirt(0, location);
+    hoeDirt.crop = null;
+    location.terrainFeatures.Add(tile, hoeDirt);
+    
+    fixture.MockSoilHealthService.Setup(x => x.GetSoilHealth("Farm", tile)).Returns(50f);
+    fixture.SeasonStub.CurrentSeason = "spring";
+    
+    fixture.Service.ProcessDayStart("Farm");
+    
+    fixture.MockSoilHealthService.Verify(x => x.UpdateHealth("Farm", tile, -1f)); // 2f * 0.5f = 1f
+}
+```
+
+---
+
+## Contract 8: SaveIdProviderFixture
+
+### Purpose
+Create `SaveIdProvider` with controlled `Constants.SaveFolderName` values.
+
+### Interface
+
+```csharp
+public class SaveIdProviderFixture : IDisposable
+{
+    public SaveIdProvider Provider { get; }
+    
+    public SaveIdProviderFixture(string? saveFolderName);
+    public void Dispose();
+}
+```
+
+### Behavior
+- **Constructor**: Sets `Constants.SaveFolderName` via reflection
+- **Dispose()**: Restores original value
+
+### Usage
+
+```csharp
+[Fact]
+public void GetSaveId_WithValidSaveFolder_ReturnsId()
+{
+    using var fixture = new SaveIdProviderFixture("test_save_id");
+    
+    var result = fixture.Provider.GetSaveId();
+    
+    Assert.Equal("test_save_id", result);
+}
+
+[Fact]
+public void GetSaveId_WithNullSaveFolder_ReturnsNull()
+{
+    using var fixture = new SaveIdProviderFixture(null);
+    
+    var result = fixture.Provider.GetSaveId();
+    
+    Assert.Null(result);
+}
+```
+
+---
+
+## Contract 9: ThreadSafeGameLoopEventsStub
+
+### Purpose
+Existing stub for testing async event handling. Already available in `LivingRoots.Tests`.
+
+### Interface (Existing)
+
+```csharp
+public class ThreadSafeGameLoopEventsStub : IGameLoopEvents
+{
+    public int GameLaunchedAddCount { get; }
+    public int GameLaunchedRemoveCount { get; }
+    public int SaveLoadedAddCount { get; }
+    public int SaveLoadedRemoveCount { get; }
+    public int SavingAddCount { get; }
+    public int SavingRemoveCount { get; }
+    
+    // Event implementations...
+}
+```
+
+### Usage
+
+```csharp
+[Fact]
+public void RegisterEvents_SubscribesToDayStarted()
+{
+    var stub = new ThreadSafeGameLoopEventsStub();
+    // ... setup controller with stub ...
+    
+    controller.RegisterEvents();
+    
+    Assert.Equal(1, stub.DayStartedAddCount);
+}
+```
+
+---
+
+## Contract 10: ItemFactory
+
+### Purpose
+Create test items with specific properties for waste validation tests.
+
+### Interface
+
+```csharp
+public static class ItemFactory
+{
+    public static Item CreateItem(string qualifiedItemId, int category = 0);
+    public static Item CreateValidWasteItem();  // Category = -74 (Seeds)
+    public static Item CreateInvalidWasteItem(); // Category = -999
+    public static Item CreateNullItem();         // Returns null!
+}
+```
+
+### Usage
+
+```csharp
+[Fact]
+public void IsValidOrganicWaste_ValidItem_ReturnsTrue()
+{
+    var item = ItemFactory.CreateValidWasteItem();
+    var validator = new OrganicWasteValidator(_mockMonitor.Object);
+    
+    var result = validator.IsValidOrganicWaste(item);
+    
+    Assert.True(result);
+}
+```
+
+---
+
+## Test File Conventions
+
+### File Naming
+- One test file per subject: `{Subject}Tests.cs`
+- Placed in `LivingRoots.Tests/` root directory
+
+### Class Naming
+- Test class name matches file name: `CompostingBinServiceTests`
+- Test namespace: `LivingRoots.Tests`
+
+### Method Naming
+- Pattern: `{Method}_{State}_{ExpectedResult}`
+- Example: `AddWaste_ValidItem_TransitionsToProcessing`
+
+### Test Structure
+1. **Arrange**: Set up fixtures, mocks, and initial state
+2. **Act**: Call the method under test
+3. **Assert**: Verify expected outcome
+
+### Required Using Statements
+
+```csharp
+using Xunit;
+using Moq;
+using LivingRoots.Domain;
+using LivingRoots.Services;
+using LivingRoots.Domain.Services;
+using StardewValley;
+using StardewValley.TerrainFeatures;
+using Microsoft.Xna.Framework;
+```
+
+---
+
+## Dependency Injection Pattern
+
+All test fixtures follow constructor injection:
+
+```csharp
+public class ServiceTests
+{
+    private readonly Mock<IDependency> _mockDep;
+    private readonly ServiceUnderTest _service;
+    
+    public ServiceTests()
+    {
+        _mockDep = new Mock<IDependency>();
+        _service = new ServiceUnderTest(_mockDep.Object);
+    }
+}
+```
+
+---
+
+## Mock Verification Pattern
+
+```csharp
+// Verify method was called
+_mockDep.Verify(x => x.Method(), Times.Once);
+
+// Verify method was never called
+_mockDep.Verify(x => x.Method(), Times.Never);
+
+// Verify method was called with specific arguments
+_mockDep.Verify(x => x.Method(expectedArg), Times.Once);
+
+// Verify property getter was accessed
+_mockDep.VerifyGet(x => x.Property, Times.Once);
+
+// Verify property setter was accessed
+_mockDep.VerifySet(x => x.Property = expectedValue, Times.Once);
+```
+
+---
+
+## Exception Testing Pattern
+
+```csharp
+[Fact]
+public void Constructor_NullDependency_ThrowsArgumentNullException()
+{
+    Assert.Throws<ArgumentNullException>(() => new ServiceUnderTest(null!));
+}
+
+[Fact]
+public void Method_InvalidArgument_ThrowsArgumentException()
+{
+    var ex = Assert.Throws<ArgumentException>(() => _service.Method(invalidArg));
+    Assert.Contains("expected message", ex.Message);
+}
+```
+
+---
+
+## Async Testing Pattern
+
+```csharp
+[Fact]
+public async Task MethodAsync_ReturnsExpectedResult()
+{
+    // Arrange
+    _mockDep.Setup(x => x.MethodAsync()).ReturnsAsync(expectedResult);
+    
+    // Act
+    var result = await _service.MethodAsync();
+    
+    // Assert
+    Assert.Equal(expectedResult, result);
+}
+```

--- a/specs/003-composting-tests/contracts/test-patterns.md
+++ b/specs/003-composting-tests/contracts/test-patterns.md
@@ -1,0 +1,246 @@
+# Test Pattern Contracts
+
+**Date**: 2026-09-07
+**Feature**: Composting State Machine Tests (`specs/003-composting-tests/`)
+
+## Overview
+
+This document defines the test pattern contracts for each service under test. Each contract specifies the test scenarios, expected behaviors, and verification methods. All time/season/player dependencies use stub implementations of the extracted interfaces (`ITimeProvider`, `ISeasonProvider`, `IPlayerProvider`).
+
+---
+
+## Contract: CompostingBinServiceTests
+
+### FR Coverage: FR-1.1 through FR-1.13
+
+### Test Scenarios
+
+| Test Name | FR | Scenario | Expected Result |
+|-----------|----|----------|-----------------|
+| `GetBinState_NewBin_ReturnsEmpty` | FR-1.1 | Query state of unknown tile | Returns `Empty` |
+| `AddWaste_ValidItem_TransitionsToProcessing` | FR-1.2 | Add valid waste to empty bin | State = `Processing` |
+| `ProcessDayStart_AfterTwoDays_TransitionsToReady` | FR-1.3 | Advance 2 days via `TimeProviderStub`, call `ProcessDayStart` | State = `Ready` |
+| `CollectCompost_FromReadyBin_ReturnsCompostCount` | FR-1.4 | Collect from ready bin | Returns `MaturationLevel`, state = `Empty` |
+| `AddWaste_ToProcessingBin_IsIgnored` | FR-1.5 | Add waste while processing | State unchanged |
+| `AddWaste_ToReadyBin_IsIgnored` | FR-1.6 | Add waste while ready | State unchanged |
+| `CollectCompost_FromEmptyBin_ReturnsZero` | FR-1.7 | Collect from empty bin | Returns 0 |
+| `CollectCompost_FromProcessingBin_ReturnsZero` | FR-1.8 | Collect from processing bin | Returns 0 |
+| `ProcessDayStart_AtThreshold_TransitionsCorrectly` | FR-1.9 | Advance exactly 2 days | Transitions at correct time |
+| `FullLifecycle_AddProcessReadyCollectAddAgain` | FR-1.10 | Complete cycle twice | Full cycle works |
+| `ProcessDayStart_SevenActiveDays_IncrementsMaturation` | FR-1.11 | 7 consecutive active days | `MaturationLevel += 1` |
+| `ProcessDayStart_FourteenIdleDays_ResetsMaturation` | FR-1.12 | 14 consecutive idle days | `MaturationLevel = 1` |
+| `CollectCompost_OutputCountEqualsMaturationLevel` | FR-1.13 | Collect at maturation level 3 | Returns 3 compost |
+| `AddWaste_InvalidItem_IsIgnored` | FR-1.2 | Add invalid waste item | State unchanged |
+| `ProcessDayStart_EmptyLocation_IsNoOp` | - | Process empty location | No exception |
+
+### Verification Methods
+
+```csharp
+// State verification
+Assert.Equal(CompostingBinState.Processing, _service.GetBinState("Farm", tile));
+
+// Return value verification
+Assert.Equal(expectedCount, _service.CollectCompost("Farm", tile, player));
+
+// Mock verification
+_mockWasteValidator.Verify(x => x.IsValidOrganicWaste(item), Times.Once);
+
+// Time stub usage
+var timeStub = new TimeProviderStub { TotalDays = 1 };
+// ... advance time ...
+timeStub.TotalDays = 3;
+```
+
+---
+
+## Contract: CompostApplicationServiceTests
+
+### FR Coverage: FR-2.1 through FR-2.4
+
+### Test Scenarios
+
+| Test Name | FR | Scenario | Expected Result |
+|-----------|----|----------|-----------------|
+| `TryApplyCompost_ValidTile_IncreasesHealth` | FR-2.1 | Apply compost to valid tile | Returns true, health increases |
+| `TryApplyCompost_AtMaxHealth_ReturnsFalse` | FR-2.2 | Apply compost at max health | Returns false |
+| `TryApplyCompost_InvalidLocation_ReturnsFalse` | FR-2.3 | Apply to non-farm location | Returns false |
+| `TryApplyCompost_NoCompostHeld_ReturnsFalse` | FR-2.4 | Apply with null/non-compost item | Returns false |
+| `TryApplyCompost_NonHoeDirtTile_ReturnsFalse` | - | Apply to non-tilled tile | Returns false |
+| `TryApplyCompost_HealthCappedAtMax` | FR-2.2 | Apply near max health | Health capped at 100 |
+
+### Verification Methods
+
+```csharp
+// Boolean result
+Assert.True(result);
+Assert.False(result);
+
+// Health update verification
+_mockSoilHealthService.Verify(x => x.UpdateHealth("Farm", tile, ModConstants.RestorationAmount));
+
+// No update when rejected
+_mockSoilHealthService.Verify(x => x.UpdateHealth(It.IsAny<string>(), It.IsAny<Vector2>(), It.IsAny<float>()), Times.Never);
+
+// Player stub usage
+var playerStub = new PlayerProviderStub { CurrentItem = compostItem };
+```
+
+---
+
+## Contract: SoilDecayServiceTests
+
+### FR Coverage: FR-3.1 through FR-3.4
+
+### Test Scenarios
+
+| Test Name | FR | Scenario | Expected Result |
+|-----------|----|----------|-----------------|
+| `ProcessDayStart_BareTile_DecaysHealth` | FR-3.1 | Process bare tilled tile | Health decreases |
+| `ProcessDayStart_LowHealth_DoesNotGoNegative` | FR-3.2 | Process at very low health | Health stays at 0 |
+| `ProcessDayStart_AtZeroHealth_StaysAtZero` | FR-3.3 | Process at zero health | Health stays at 0 |
+| `ProcessDayStart_SummerDecay_HigherThanSpring` | FR-3.4 | Compare summer vs spring decay | Summer > Spring |
+| `ProcessDayStart_Winter_NoDecay` | FR-3.4 | Process in winter | No decay (0x multiplier) |
+| `ProcessDayStart_CoveredTile_NoDecay` | - | Process tile with crop | No decay |
+
+### Verification Methods
+
+```csharp
+// Decay amount verification
+_mockSoilHealthService.Verify(x => x.UpdateHealth("Farm", tile, -decayAmount));
+
+// No decay in winter
+_mockSoilHealthService.Verify(x => x.UpdateHealth(It.IsAny<string>(), It.IsAny<Vector2>(), It.IsAny<float>()), Times.Never);
+
+// Season stub usage
+var seasonStub = new SeasonProviderStub { CurrentSeason = "summer" };
+```
+
+---
+
+## Contract: OrganicWasteValidatorTests
+
+### FR Coverage: FR-4.1 through FR-4.3
+
+### Test Scenarios
+
+| Test Name | FR | Scenario | Expected Result |
+|-----------|----|----------|-----------------|
+| `IsValidOrganicWaste_Seeds_ReturnsTrue` | FR-4.1 | Category -74 (Seeds) | Returns true |
+| `IsValidOrganicWaste_Vegetables_ReturnsTrue` | FR-4.1 | Category -75 (Vegetables) | Returns true |
+| `IsValidOrganicWaste_Fruits_ReturnsTrue` | FR-4.1 | Category -79 (Fruits) | Returns true |
+| `IsValidOrganicWaste_Flowers_ReturnsTrue` | FR-4.1 | Category -80 (Flowers) | Returns true |
+| `IsValidOrganicWaste_Forage_ReturnsTrue` | FR-4.1 | Category -81 (Forage) | Returns true |
+| `IsValidOrganicWaste_Stone_ReturnsFalse` | FR-4.2 | Category -12 (Stone) | Returns false |
+| `IsValidOrganicWaste_Wood_ReturnsFalse` | FR-4.2 | Category -14 (Wood) | Returns false |
+| `IsValidOrganicWaste_NullItem_ReturnsFalse` | FR-4.3 | Null item | Returns false |
+| `IsValidOrganicWaste_CompostableTag_ReturnsTrue` | - | Item with `compostable_item` tag | Returns true |
+| `IsValidOrganicWaste_NotCompostableTag_ReturnsFalse` | - | Item with `not_compostable` tag | Returns false |
+
+### Verification Methods
+
+```csharp
+Assert.True(result);
+Assert.False(result);
+```
+
+---
+
+## Contract: SeasonalDecayMultiplierTests
+
+### FR Coverage: FR-5.1 through FR-5.5
+
+### Test Scenarios
+
+| Test Name | FR | Scenario | Expected Result |
+|-----------|----|----------|-----------------|
+| `GetMultiplier_Spring_ReturnsHalf` | FR-5.1 | "spring" | Returns 0.5f |
+| `GetMultiplier_Summer_ReturnsOneAndHalf` | FR-5.2 | "summer" | Returns 1.5f |
+| `GetMultiplier_Fall_ReturnsHalf` | FR-5.3 | "fall" | Returns 0.5f |
+| `GetMultiplier_Winter_ReturnsZero` | FR-5.4 | "winter" | Returns 0.0f |
+| `GetMultiplier_InvalidSeason_ReturnsDefault` | FR-5.5 | "invalid" | Returns 0.5f (default) |
+
+### Verification Methods
+
+```csharp
+Assert.Equal(0.5f, _multiplier.GetMultiplier("spring"));
+Assert.Equal(1.5f, _multiplier.GetMultiplier("summer"));
+```
+
+---
+
+## Contract: SaveIdProviderTests
+
+### FR Coverage: FR-6.1 through FR-6.3
+
+### Test Scenarios
+
+| Test Name | FR | Scenario | Expected Result |
+|-----------|----|----------|-----------------|
+| `GetSaveId_WithValidSaveFolder_ReturnsId` | FR-6.1 | Valid save folder | Returns save ID |
+| `GetSaveId_WithNullSaveFolder_ReturnsNull` | FR-6.2 | Null save folder | Returns null |
+| `GetSaveId_WithEmptySaveFolder_ReturnsNull` | FR-6.2 | Empty save folder | Returns null |
+| `GetSaveId_WithWhitespaceSaveFolder_ReturnsNull` | FR-6.2 | Whitespace save folder | Returns null |
+| `GetSaveId_WithTooLongSaveFolder_ReturnsNull` | - | Save folder > 200 chars | Returns null |
+| `GetSaveId_MultipleCalls_ReturnsSameId` | FR-6.3 | Multiple calls | Returns same ID |
+
+### Verification Methods
+
+```csharp
+Assert.Equal("test_save_id", result);
+Assert.Null(result);
+```
+
+---
+
+## Contract: CompostingBinFactoryTests
+
+### FR Coverage: FR-7.1 through FR-7.2
+
+### Test Scenarios
+
+| Test Name | FR | Scenario | Expected Result |
+|-----------|----|----------|-----------------|
+| `CreateBin_ReturnsEmptyState` | FR-7.1 | Create new bin | State = Empty |
+| `CreateBin_HasCorrectDefaults` | FR-7.2 | Create new bin | MaturationLevel = 1, TileX/Y match |
+| `CreateBin_DifferentCoordinates` | FR-7.2 | Create at different coords | TileX/Y match input |
+
+### Verification Methods
+
+```csharp
+var bin = _factory.CreateBin(10, 20);
+Assert.Equal(CompostingBinState.Empty, bin.State);
+Assert.Equal(1, bin.MaturationLevel);
+Assert.Equal(10, bin.TileX);
+Assert.Equal(20, bin.TileY);
+```
+
+---
+
+## Test Execution Contract
+
+### Build Verification
+
+```bash
+dotnet build Stardew-LivingRoots.sln --configuration Release
+```
+
+### Test Filter
+
+```bash
+dotnet test Stardew-LivingRoots.sln --no-build --verbosity normal \
+  --filter "FullyQualifiedName~Composting|FullyQualifiedName~SoilDecay|FullyQualifiedName~OrganicWaste|FullyQualifiedName~SeasonalDecay|FullyQualifiedName~SaveIdProvider|FullyQualifiedName~CompostingBinFactory"
+```
+
+### Expected Output
+
+```
+Passed!  - Failed:     0, Passed:    ~44, Skipped:     0, Total:    ~44
+```
+
+### Performance Contract
+
+- All tests complete in under 5 seconds (NFR-1)
+- Tests do not depend on external systems (NFR-2)
+- Tests are deterministic (NFR-3)
+- Tests do not use reflection to access private state (NFR-4)
+- Tests follow existing project conventions (NFR-5)

--- a/specs/003-composting-tests/data-model.md
+++ b/specs/003-composting-tests/data-model.md
@@ -1,0 +1,358 @@
+# Data Model: Composting State Machine Tests
+
+**Date**: 2026-09-07
+**Feature**: Composting State Machine Tests (`specs/003-composting-tests/`)
+
+## Overview
+
+This document defines the data entities, state transitions, and validation rules for the composting system. These models are used by the test suite to verify correct behavior. It also defines the new testable interfaces extracted from `Game1` static dependencies.
+
+---
+
+## Entities
+
+### CompostingBinStateModel
+
+The runtime state of a single composting bin.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `TileX` | `int` | - | X coordinate of the bin's tile |
+| `TileY` | `int` | - | Y coordinate of the bin's tile |
+| `State` | `CompostingBinState` | `Empty` | Current state (Empty, Processing, Ready) |
+| `InputItemId` | `string?` | `null` | QualifiedItemId of the waste item added |
+| `InputTimestamp` | `int?` | `null` | Day when waste was added (`ITimeProvider.TotalDays`) — changed from `long?` to `int?` |
+| `MaturationLevel` | `int` | `1` | Current maturation level (1-5) |
+| `ConsecutiveIdleDays` | `int` | `0` | Days spent in Empty state |
+| `ConsecutiveActiveDays` | `int` | `0` | Days spent in Processing state |
+
+**Validation Rules**:
+- `MaturationLevel` must be between 1 and `MaturationMaxLevel` (5)
+- `ConsecutiveIdleDays` must be between 0 and `MaturationIdleResetDays` (14)
+- `InputTimestamp` is required when `State == Processing`
+
+---
+
+### CompostingBinState (Enum)
+
+```csharp
+public enum CompostingBinState
+{
+    Empty = 0,
+    Processing = 1,
+    Ready = 2
+}
+```
+
+---
+
+### CompostingBinData
+
+The persistence DTO for composting bin state. **Updated to include `ConsecutiveActiveDays`** (Fix-3).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `LocationBinData` | `Dictionary<string, Dictionary<string, CompostingBinStateData>>` | Bins keyed by location name, then tile key |
+
+---
+
+### CompostingBinStateData
+
+The persistence DTO for a single bin. **Updated to include `ConsecutiveActiveDays`** (Fix-3).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `State` | `string` | State name (Empty, Processing, Ready) |
+| `InputItemId` | `string?` | QualifiedItemId of waste item |
+| `InputTimestamp` | `int?` | Day when waste was added (changed from `long?` to `int?`) |
+| `MaturationLevel` | `int` | Current maturation level |
+| `ConsecutiveIdleDays` | `int` | Days spent idle |
+| `ConsecutiveActiveDays` | `int` | Days spent active (FIX-3: added for maturation persistence) |
+
+---
+
+### SoilHealthState
+
+The persistence DTO for soil health.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `HealthData` | `Dictionary<LocationName, Dictionary<TileKey, HealthValue>>` | Health values by location and tile |
+
+---
+
+## New Testable Interfaces (Fix-4)
+
+### ITimeProvider
+
+Extracted from `Game1.Date.TotalDays` for time-dependent tests.
+
+```csharp
+// Location: LivingRoots/Domain/Interfaces/ITimeProvider.cs
+public interface ITimeProvider
+{
+    int TotalDays { get; }
+}
+```
+
+**Production implementation**: `TimeProvider` in `LivingRoots/Services/` wraps `Game1.Date.TotalDays`.
+**Test implementation**: `TimeProviderStub` with settable `TotalDays` property.
+
+---
+
+### ISeasonProvider
+
+Extracted from `Game1.currentSeason` for season-dependent tests.
+
+```csharp
+// Location: LivingRoots/Domain/Interfaces/ISeasonProvider.cs
+public interface ISeasonProvider
+{
+    string CurrentSeason { get; }
+}
+```
+
+**Production implementation**: `SeasonProvider` in `LivingRoots/Services/` wraps `Game1.currentSeason`.
+**Test implementation**: `SeasonProviderStub` with settable `CurrentSeason` property.
+
+---
+
+### IPlayerProvider
+
+Extracted from `Game1.player` for player-dependent tests.
+
+```csharp
+// Location: LivingRoots/Domain/Interfaces/IPlayerProvider.cs
+public interface IPlayerProvider
+{
+    Farmer CurrentPlayer { get; }
+    Item? CurrentItem { get; }
+}
+```
+
+**Production implementation**: `PlayerProvider` in `LivingRoots/Services/` wraps `Game1.player`.
+**Test implementation**: `PlayerProviderStub` with settable `CurrentItem` property.
+
+---
+
+## State Transitions
+
+### Composting Bin State Machine
+
+```
+┌─────────┐    Add valid waste     ┌────────────┐    2 full days elapsed    ┌─────────┐
+│  Empty  │ ─────────────────────► │ Processing │ ────────────────────────► │  Ready  │
+└─────────┘                        └────────────┘                           └─────────┘
+     ▲                                                                              │
+     │                                                                              │
+     │                                 Collect compost                              │
+     └──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Transition Rules
+
+| From | To | Condition | Action |
+|------|----|-----------|--------|
+| Empty | Processing | `AddWaste()` called with valid item | Set `InputTimestamp = ITimeProvider.TotalDays`, increment idle days reset |
+| Processing | Ready | `ITimeProvider.TotalDays - InputTimestamp >= MaturationDays (2)` | Play sound, log transition |
+| Ready | Empty | `CollectCompost()` called | Produce `MaturationLevel` compost items, reset state |
+| Empty | Empty | `AddWaste()` called with invalid item | No state change (silently ignored) |
+| Processing | Processing | `AddWaste()` called | No state change (silently ignored) |
+| Ready | Ready | `AddWaste()` called | No state change (silently ignored) |
+
+### Maturation Rules
+
+| Condition | Effect |
+|-----------|--------|
+| 7 consecutive active days (Processing) | `MaturationLevel += 1` (capped at 5) |
+| 14 consecutive idle days (Empty) | `MaturationLevel = 1` |
+| Collect compost | Output count = `MaturationLevel` |
+
+---
+
+## Test Fixtures
+
+### TimeProviderStub
+
+Stub implementation of `ITimeProvider` for time-dependent tests.
+
+```csharp
+public class TimeProviderStub : ITimeProvider
+{
+    public int TotalDays { get; set; } = 1;
+}
+```
+
+### SeasonProviderStub
+
+Stub implementation of `ISeasonProvider` for season-dependent tests.
+
+```csharp
+public class SeasonProviderStub : ISeasonProvider
+{
+    public string CurrentSeason { get; set; } = "spring";
+}
+```
+
+### PlayerProviderStub
+
+Stub implementation of `IPlayerProvider` for player-dependent tests.
+
+```csharp
+public class PlayerProviderStub : IPlayerProvider
+{
+    public Farmer CurrentPlayer { get; set; } = null!;
+    public Item? CurrentItem { get; set; }
+}
+```
+
+### GameLocationFixture
+
+Helper class to create real `GameLocation` instances with `HoeDirt` tiles.
+
+```csharp
+public class GameLocationFixture
+{
+    public GameLocation Location { get; }
+    public List<Vector2> TilledTiles { get; } = new();
+    
+    public GameLocationFixture(string mapPath = "Maps\\Farm", string name = "Farm")
+    {
+        Location = new GameLocation(mapPath, name);
+    }
+    
+    public void AddHoeDirtTile(int x, int y, bool bare = true)
+    {
+        var tile = new Vector2(x, y);
+        var hoeDirt = new HoeDirt(0, Location);
+        if (!bare) hoeDirt.crop = new Crop(0, x, y);
+        Location.terrainFeatures.Add(tile, hoeDirt);
+        TilledTiles.Add(tile);
+    }
+}
+```
+
+### CompostingBinFixture
+
+Helper class to create `CompostingBinService` with mock dependencies.
+
+```csharp
+public class CompostingBinFixture
+{
+    public Mock<IModDataService> MockModDataService { get; }
+    public Mock<ISaveIdProvider> MockSaveIdProvider { get; }
+    public Mock<IOrganicWasteValidator> MockWasteValidator { get; }
+    public Mock<IMonitor> MockMonitor { get; }
+    public TimeProviderStub TimeStub { get; }
+    public CompostingBinFactory Factory { get; }
+    public CompostingBinService Service { get; }
+    
+    public CompostingBinFixture()
+    {
+        MockModDataService = new Mock<IModDataService>();
+        MockSaveIdProvider = new Mock<ISaveIdProvider>();
+        MockWasteValidator = new Mock<IOrganicWasteValidator>();
+        MockMonitor = new Mock<IMonitor>();
+        TimeStub = new TimeProviderStub();
+        Factory = new CompostingBinFactory();
+        
+        Service = new CompostingBinService(
+            MockModDataService.Object,
+            MockSaveIdProvider.Object,
+            MockWasteValidator.Object,
+            MockMonitor.Object,
+            TimeStub,
+            Factory);
+    }
+}
+```
+
+---
+
+## Validation Rules for Tests
+
+### FR-1: CompostingBinService State Machine
+
+| ID | Rule | Test Verification |
+|----|------|-------------------|
+| FR-1.1 | New bin starts Empty | `GetBinState` returns `Empty` for unknown tile |
+| FR-1.2 | Add valid waste → Processing | State changes to `Processing` |
+| FR-1.3 | 2 days elapsed → Ready | State changes to `Ready` after `ProcessDayStart` |
+| FR-1.4 | Collect → Empty | State returns to `Empty`, returns compost count |
+| FR-1.5 | Add to Processing → ignored | State remains `Processing` |
+| FR-1.6 | Add to Ready → ignored | State remains `Ready` |
+| FR-1.7 | Collect from Empty → 0 | Returns 0, state unchanged |
+| FR-1.8 | Collect from Processing → 0 | Returns 0, state unchanged |
+| FR-1.9 | Time progression at threshold | Transitions at exactly 2 days |
+| FR-1.10 | Full lifecycle | Add → Process → Ready → Collect → Add again |
+| FR-1.11 | Maturation increment | Level increases after 7 active days |
+| FR-1.12 | Maturation reset | Level resets after 14 idle days |
+| FR-1.13 | Output equals maturation level | Collect returns `MaturationLevel` items |
+
+### FR-2: CompostApplicationService
+
+| ID | Rule | Test Verification |
+|----|------|-------------------|
+| FR-2.1 | Apply compost increases health | Health increases by `RestorationAmount` |
+| FR-2.2 | Health capped at max | Health does not exceed `MaxSoilHealth` |
+| FR-2.3 | Invalid location returns false | Non-farm, non-Greenhouse returns false |
+| FR-2.4 | No compost held returns false | `CurrentItem` is null or non-compost |
+
+### FR-3: SoilDecayService
+
+| ID | Rule | Test Verification |
+|----|------|-------------------|
+| FR-3.1 | Health decreases over time | Health decreases by `DailyDecayRate × multiplier` |
+| FR-3.2 | Health floored at min | Health does not go below `MinSoilHealth` |
+| FR-3.3 | Health never negative | Health stays at 0 minimum |
+| FR-3.4 | Seasonal variation | Different seasons apply different multipliers |
+
+### FR-4: OrganicWasteValidator
+
+| ID | Rule | Test Verification |
+|----|------|-------------------|
+| FR-4.1 | Valid items accepted | Categories -74, -75, -79, -80, -81 return true |
+| FR-4.2 | Invalid items rejected | Other categories return false |
+| FR-4.3 | Null input returns false | `null` item returns false |
+
+### FR-5: SeasonalDecayMultiplier
+
+| ID | Rule | Test Verification |
+|----|------|-------------------|
+| FR-5.1 | Spring multiplier | Returns 0.5f |
+| FR-5.2 | Summer multiplier | Returns 1.5f |
+| FR-5.3 | Fall multiplier | Returns 0.5f |
+| FR-5.4 | Winter multiplier | Returns 0.0f |
+| FR-5.5 | Invalid season | Returns 0.5f (default) |
+
+### FR-6: SaveIdProvider
+
+| ID | Rule | Test Verification |
+|----|------|-------------------|
+| FR-6.1 | Valid save ID | Returns non-null, non-empty string |
+| FR-6.2 | Null save folder | Returns null |
+| FR-6.3 | Consistency | Returns same ID across multiple calls |
+
+### FR-7: CompostingBinFactory
+
+| ID | Rule | Test Verification |
+|----|------|-------------------|
+| FR-7.1 | Creates bin in Empty state | `State == Empty` |
+| FR-7.2 | Correct defaults | `MaturationLevel == 1`, tile coordinates match |
+
+---
+
+## Constants Reference
+
+| Constant | Value | Used By |
+|----------|-------|---------|
+| `MaturationDays` | 2 | CompostingBinService (replaces `ProcessingDurationMinutes = 2880` after Fix-1) |
+| `MaturationMaxLevel` | 5 | CompostingBinService |
+| `MaturationIdleResetDays` | 14 | CompostingBinService |
+| `MaturationIncrementDays` | 7 | CompostingBinService |
+| `CompostItemId` | "LivingRoots.Compost" | CompostApplicationService |
+| `DailyDecayRate` | 2f | SoilDecayService |
+| `RestorationAmount` | 15f | CompostApplicationService |
+| `MaxSoilHealth` | 100f | CompostApplicationService, SoilDecayService |
+| `MinSoilHealth` | 0f | SoilDecayService |
+| `MaxSaveIdLength` | 200 | SaveIdProvider |

--- a/specs/003-composting-tests/quickstart.md
+++ b/specs/003-composting-tests/quickstart.md
@@ -1,0 +1,288 @@
+# Quickstart: Composting State Machine Tests
+
+**Date**: 2026-09-07
+**Feature**: Composting State Machine Tests (`specs/003-composting-tests/`)
+
+## Overview
+
+This guide provides runnable validation scenarios to prove the composting test suite works end-to-end. Run these after implementing the prerequisite fixes and test files. All tests use stub implementations of `ITimeProvider`, `ISeasonProvider`, and `IPlayerProvider` — no direct `Game1` access required.
+
+---
+
+## Prerequisites
+
+- .NET 6 SDK
+- Stardew Valley game files (for `GameLocation`, `HoeDirt`, `Item` classes)
+- SMAPI installed
+- Existing `LivingRoots.Tests` project configured
+
+---
+
+## Quick Validation (5 minutes)
+
+### Step 1: Build the test project
+
+```bash
+cd /home/luis/development/stardew-raizes-vivas
+dotnet build Stardew-LivingRoots.sln --configuration Release
+```
+
+**Expected**: Build succeeds with no errors.
+
+### Step 2: Run all composting tests
+
+```bash
+dotnet test Stardew-LivingRoots.sln --no-build --verbosity normal --filter "FullyQualifiedName~Composting|FullyQualifiedName~SoilDecay|FullyQualifiedName~OrganicWaste|FullyQualifiedName~SeasonalDecay|FullyQualifiedName~SaveIdProvider|FullyQualifiedName~CompostingBinFactory"
+```
+
+**Expected**: All tests pass. Output shows:
+```
+Passed!  - Failed:     0, Passed:    ~44, Skipped:     0, Total:    ~44
+```
+
+### Step 3: Verify test execution time
+
+```bash
+dotnet test Stardew-LivingRoots.sln --no-build --verbosity normal --filter "FullyQualifiedName~Composting|FullyQualifiedName~SoilDecay|FullyQualifiedName~OrganicWaste|FullyQualifiedName~SeasonalDecay|FullyQualifiedName~SaveIdProvider|FullyQualifiedName~CompostingBinFactory" --logger "console;verbosity=detailed"
+```
+
+**Expected**: All tests complete in under 5 seconds (NFR-1).
+
+---
+
+## Detailed Validation Scenarios
+
+### Scenario 1: State Machine Lifecycle (FR-1.10)
+
+**Goal**: Verify the full composting lifecycle works.
+
+**Test**: `CompostingBinServiceTests.FullLifecycle_AddProcessReadyCollectAddAgain`
+
+**Steps**:
+1. Create `CompostingBinFixture`
+2. Set `TimeProviderStub.TotalDays = 1`
+3. Call `AddWaste("Farm", (10, 10), validItem)`
+4. Verify state is `Processing`
+5. Set `TimeProviderStub.TotalDays = 3`
+6. Call `ProcessDayStart("Farm")`
+7. Verify state is `Ready`
+8. Call `CollectCompost("Farm", (10, 10), player)`
+9. Verify state is `Empty` and returns 1 compost
+10. Call `AddWaste("Farm", (10, 10), validItem)` again
+11. Verify state is `Processing` again
+
+**Expected Result**: All assertions pass.
+
+---
+
+### Scenario 2: Time Progression at Threshold (FR-1.9)
+
+**Goal**: Verify the bin transitions at exactly 2 full days.
+
+**Test**: `CompostingBinServiceTests.ProcessDayStart_AfterExactlyTwoDays_TransitionsToReady`
+
+**Steps**:
+1. Set `TimeProviderStub.TotalDays = 1`
+2. Call `AddWaste("Farm", (10, 10), validItem)`
+3. Set `TimeProviderStub.TotalDays = 2` (1 day elapsed)
+4. Call `ProcessDayStart("Farm")`
+5. Verify state is still `Processing`
+6. Set `TimeProviderStub.TotalDays = 3` (2 days elapsed)
+7. Call `ProcessDayStart("Farm")`
+8. Verify state is `Ready`
+
+**Expected Result**: State transitions at exactly 2 days, not before.
+
+---
+
+### Scenario 3: Maturation Increment (FR-1.11)
+
+**Goal**: Verify maturation level increases after 7 active days.
+
+**Test**: `CompostingBinServiceTests.ProcessDayStart_SevenActiveDays_IncrementsMaturationLevel`
+
+**Steps**:
+1. Set `TimeProviderStub.TotalDays = 1`
+2. Call `AddWaste("Farm", (10, 10), validItem)`
+3. For days 2-8: set `TimeProviderStub.TotalDays` and call `ProcessDayStart("Farm")` each day
+4. Verify `MaturationLevel` increased from 1 to 2
+
+**Expected Result**: Maturation level increments after 7 consecutive active days.
+
+---
+
+### Scenario 4: Maturation Reset (FR-1.12)
+
+**Goal**: Verify maturation level resets after 14 idle days.
+
+**Test**: `CompostingBinServiceTests.ProcessDayStart_FourteenIdleDays_ResetsMaturationLevel`
+
+**Steps**:
+1. Set maturation level to 3 (via multiple cycles)
+2. Set `TimeProviderStub.TotalDays = 1`
+3. For days 2-15: set `TimeProviderStub.TotalDays` and call `ProcessDayStart("Farm")` each day (bin stays Empty)
+4. Verify `MaturationLevel` reset to 1
+
+**Expected Result**: Maturation level resets to 1 after 14 consecutive idle days.
+
+---
+
+### Scenario 5: Invalid Transitions (FR-1.5, FR-1.6)
+
+**Goal**: Verify adding waste to non-Empty bins is silently ignored.
+
+**Test**: `CompostingBinServiceTests.AddWaste_ToProcessingBin_IsIgnored`
+
+**Steps**:
+1. Set `TimeProviderStub.TotalDays = 1`
+2. Call `AddWaste("Farm", (10, 10), validItem)` → state is `Processing`
+3. Call `AddWaste("Farm", (10, 10), validItem)` again
+4. Verify state is still `Processing`
+
+**Expected Result**: Second `AddWaste` call is silently ignored.
+
+---
+
+### Scenario 6: Collect from Empty/Processing (FR-1.7, FR-1.8)
+
+**Goal**: Verify collecting from non-Ready bins returns 0.
+
+**Test**: `CompostingBinServiceTests.CollectCompost_FromEmptyBin_ReturnsZero`
+
+**Steps**:
+1. Call `CollectCompost("Farm", (10, 10), player)` on empty bin
+2. Verify returns 0
+
+**Expected Result**: Returns 0, no state change.
+
+---
+
+### Scenario 7: Seasonal Decay Variation (FR-3.4)
+
+**Goal**: Verify decay rate changes by season.
+
+**Test**: `SoilDecayServiceTests.ProcessDayStart_SummerDecay_HigherThanSpring`
+
+**Steps**:
+1. Create `GameLocationFixture("Maps\\Farm", "Farm")` with bare `HoeDirt` tiles
+2. Set `SeasonProviderStub.CurrentSeason = "spring"`
+3. Call `ProcessDayStart("Farm")`
+4. Record health lost
+5. Reset health
+6. Set `SeasonProviderStub.CurrentSeason = "summer"`
+7. Call `ProcessDayStart("Farm")`
+8. Record health lost
+9. Verify summer decay > spring decay
+
+**Expected Result**: Summer (1.5x) decay is higher than spring (0.5x).
+
+---
+
+### Scenario 8: Soil Health Bounds (FR-3.2, FR-3.3)
+
+**Goal**: Verify health never goes below 0.
+
+**Test**: `SoilDecayServiceTests.ProcessDayStart_LowHealth_DoesNotGoNegative`
+
+**Steps**:
+1. Set soil health to very low value (e.g., 1.0)
+2. Call `ProcessDayStart("Farm")`
+3. Verify health is 0 (not negative)
+
+**Expected Result**: Health clamped at 0.
+
+---
+
+### Scenario 9: Waste Validation (FR-4.1, FR-4.2)
+
+**Goal**: Verify valid/invalid items are correctly categorized.
+
+**Test**: `OrganicWasteValidatorTests.IsValidOrganicWaste_ValidItems_ReturnTrue`
+
+**Steps**:
+1. Create item with `Category = -74` (Seeds)
+2. Call `IsValidOrganicWaste(item)`
+3. Verify returns true
+4. Create item with `Category = -999` (Invalid)
+5. Call `IsValidOrganicWaste(item)`
+6. Verify returns false
+
+**Expected Result**: Valid categories accepted, invalid rejected.
+
+---
+
+### Scenario 10: Save ID Provider (FR-6.1, FR-6.2)
+
+**Goal**: Verify save ID retrieval and null handling.
+
+**Test**: `SaveIdProviderTests.GetSaveId_WithValidSaveFolder_ReturnsId`
+
+**Steps**:
+1. Set `Constants.SaveFolderName = "test_save"` via reflection
+2. Create `SaveIdProvider`
+3. Call `GetSaveId()`
+4. Verify returns "test_save"
+5. Set `Constants.SaveFolderName = null`
+6. Call `GetSaveId()`
+7. Verify returns null
+
+**Expected Result**: Returns valid ID when available, null when not.
+
+---
+
+## Test Execution Summary
+
+| Test File | Scenarios Covered | Expected Pass |
+|-----------|-------------------|---------------|
+| `CompostingBinServiceTests` | 1-6 | 15 tests |
+| `CompostApplicationServiceTests` | - | 6 tests |
+| `SoilDecayServiceTests` | 7-8 | 6 tests |
+| `OrganicWasteValidatorTests` | 9 | 5 tests |
+| `SeasonalDecayMultiplierTests` | - | 5 tests |
+| `SaveIdProviderTests` | 10 | 4 tests |
+| `CompostingBinFactoryTests` | - | 3 tests |
+| **Total** | | **~44 tests** |
+
+---
+
+## Troubleshooting
+
+### TimeProviderStub not advancing time
+
+**Symptom**: State never transitions to Ready.
+
+**Solution**: Ensure `TimeProviderStub.TotalDays` is set BEFORE calling `ProcessDayStart()`. The stub value is read at the time of the call.
+
+### SeasonProviderStub not changing decay
+
+**Symptom**: Decay amount same across seasons.
+
+**Solution**: Ensure `SeasonProviderStub.CurrentSeason` is set BEFORE calling `ProcessDayStart()`. Verify the season string matches expected values ("spring", "summer", "fall", "winter").
+
+### Constants.SaveFolderName not settable
+
+**Symptom**: `FieldInfo.SetValue` throws `FieldAccessException`.
+
+**Solution**: Use `BindingFlags.Public | BindingFlags.Static` and ensure the field is not readonly. If readonly, use `GetField` with appropriate flags.
+
+### GameLocation constructor throws
+
+**Symptom**: `ArgumentException` when creating `GameLocation`.
+
+**Solution**: Use the correct constructor signature `GameLocation(string mapPath, string name)` — first parameter is the map file path (e.g., `"Maps\\Farm"`), not the display name.
+
+### ThreadSafeGameLoopEventsStub not found
+
+**Symptom**: `TypeNotFoundException` for `ThreadSafeGameLoopEventsStub`.
+
+**Solution**: Verify the file exists at `LivingRoots.Tests/ThreadSafeGameLoopEventsStub.cs`. If missing, create it from the existing test infrastructure.
+
+---
+
+## Next Steps
+
+1. Review the test files generated by `/speckit-tasks`
+2. Implement prerequisite fixes (Fix-1 through Fix-5)
+3. Create test files following the patterns in this guide
+4. Run the quickstart validation scenarios
+5. Verify all tests pass

--- a/specs/003-composting-tests/research.md
+++ b/specs/003-composting-tests/research.md
@@ -1,0 +1,269 @@
+# Research: Composting State Machine Tests
+
+**Date**: 2026-09-07
+**Feature**: Composting State Machine Tests (`specs/003-composting-tests/`)
+
+## Research Questions
+
+### Q1: How to test `Game1` static class dependencies?
+
+**Decision**: Extract `Game1` dependencies behind thin interfaces (`ITimeProvider`, `ISeasonProvider`, `IPlayerProvider`) placed in `Domain/Interfaces/`. Services accept these via constructor injection. Production implementations wire to real `Game1`; tests use stub implementations.
+
+**Rationale**:
+- `Game1.graphics` and `Game1.smallFont` require an XNA graphics device unavailable in unit tests
+- `Game1.player` setter disposes the previous value
+- xUnit parallelization conflicts with `Game1` static mutable state
+- The project's existing DDD convention (interface in `Domain/Interfaces/`, impl in `Services/`) supports this approach
+- Spec clarification Round 2 confirmed this approach
+- Existing project tests (e.g., `ModControllerTests`) use Moq for interface dependencies — this extends the same pattern
+
+**Alternatives Considered**:
+- Real `Game1` with snapshot/restore helper — rejected: XNA graphics dependencies, player disposal semantics, parallelization conflicts
+- `ITimeProvider` interface with mock implementation — evolved into full interface extraction (Fix-4)
+- Isolation framework like `Pose` or `Smocks` — rejected: external dependency, overkill for this use case
+
+---
+
+### Q2: How to test time-dependent state transitions?
+
+**Decision**: Set `ITimeProvider.TotalDays` via stub implementation and call `ProcessDayStart()` directly. The constant `MaturationDays = 2` replaces `ProcessingDurationMinutes = 2880` for whole-day comparison.
+
+**Rationale**:
+- `ITimeProvider.TotalDays` returns `int` — whole-day granularity matches the fix for the cross-day elapsed time bug
+- Tests control time by setting the stub's `TotalDays` property and calling `ProcessDayStart()`
+- Production wires `ITimeProvider` to `Game1.Date.TotalDays`
+- `InputTimestamp` type changes from `long?` to `int?` (remains nullable because set to `null` when bin is empty)
+
+**Alternatives Considered**:
+- Using `Game1.timeOfDay` — rejected: resets to 0 each day, causes negative elapsed time
+- Creating a custom time abstraction — rejected: the thin interface approach is simpler and follows existing DDD convention
+
+---
+
+### Q3: How to test `CompostingBinController` event wiring?
+
+**Decision**: Merge `CompostingBinController` logic (right-click waste add / compost collect) into `ModController` as a new `OnButtonPressed` event handler. Delete the standalone `CompostingBinController` class. Wire both `CompostingBinService.ProcessDayStart` AND `SoilDecayService.ProcessDayStart` to `ModController.DayStarted`.
+
+**Rationale**:
+- `CompostingBinController` exists but is orphaned — not instantiated in `ModEntry`
+- Single-controller architecture is the project pattern (`ModController` is the sole controller)
+- Both services follow the same `ProcessDayStart` pattern and are equally orphaned
+- `ThreadSafeGameLoopEventsStub` can raise `DayStarted` to test wiring
+
+**Alternatives Considered**:
+- Instantiating `CompostingBinController` separately — rejected: violates single-controller architecture
+- Using real SMAPI events — rejected: requires full game context
+
+---
+
+### Q4: How to test `SoilDecayService` location iteration?
+
+**Decision**: Create real `GameLocation` instances using the correct constructor signature `GameLocation(string mapPath, string name)` with `HoeDirt` tiles manually added.
+
+**Rationale**:
+- `SoilDecayService` iterates `location.terrainFeatures.Pairs`
+- Real `GameLocation` and `HoeDirt` objects are available in the test context
+- This is the SMAPI mod testing standard (real objects, no mocking framework overhead)
+- Spec clarification confirmed the correct constructor signature: `GameLocation(string mapPath, string name)` — first parameter is the map file path, not the display name
+
+**Alternatives Considered**:
+- Mocking `GameLocation` — rejected: complex setup, fragile tests
+- Using `Mock<GameLocation>` — rejected: `GameLocation` is not easily mockable
+
+---
+
+### Q5: How to test `SaveIdProvider` with `Constants.SaveFolderName`?
+
+**Decision**: Set `Constants.SaveFolderName` via reflection or test-only setter. Test the provider's validation logic (null, whitespace, length, consistency).
+
+**Rationale**:
+- `Constants.SaveFolderName` is a public static field in SMAPI
+- Reflection allows setting it in test setup
+- Tests verify the provider's actual logic without mocking SMAPI internals
+
+**Alternatives Considered**:
+- Using `Mock<IReflection>` — rejected: SMAPI's `Constants` is not mockable
+- Creating a wrapper interface — rejected: adds untested abstraction
+
+---
+
+### Q6: How to test maturation mechanics?
+
+**Decision**: Add explicit test cases for maturation: verify level increases after 7 consecutive active days, resets to 1 after 14 idle days, and output count equals current maturation level. These are deterministic, fast unit tests that directly verify the maturation logic.
+
+**Rationale**:
+- Maturation mechanics are only implicitly covered in the spec
+- `ConsecutiveActiveDays` must be persisted (Fix-3) for maturation to work across save/load
+- Tests use `ITimeProvider` stub to advance days and verify maturation counter behavior
+
+**Alternatives Considered**:
+- Testing maturation through full lifecycle only — rejected: less precise, harder to debug failures
+
+---
+
+### Q7: How to handle `CompostingBinFactory` dead code?
+
+**Decision**: Refactor `CompostingBinService.AddWaste` to accept `CompostingBinFactory` via constructor injection and call `_factory.CreateBin(tileX, tileY)` instead of inline `new CompostingBinStateModel`.
+
+**Rationale**:
+- The factory encapsulates default initialization (Empty state, MaturationLevel=1)
+- FR-7 (factory tests) would test a class that production never uses — pure coverage theater
+- Making the factory the single creation point prevents divergence between factory defaults and service inline initialization
+
+**Alternatives Considered**:
+- Deleting the factory — rejected: the factory provides value as a single creation point
+- Testing the factory as-is — rejected: tests a class that production never uses
+
+---
+
+### Q8: What test patterns exist in the codebase?
+
+**Decision**: Follow existing patterns from `ModControllerTests` and `ModDataServiceTests`, extended with stub implementations for the new interfaces.
+
+**Rationale**:
+- Constructor injection for test fixtures
+- `Mock<T>` for interface dependencies
+- `ThreadSafeGameLoopEventsStub` for async event testing
+- `[Fact]` attributes for test methods
+- `Assert` class for verification
+- Stub implementations for `ITimeProvider`, `ISeasonProvider`, `IPlayerProvider`
+
+**Key Patterns Identified**:
+1. **Constructor setup**: All mocks created in constructor, stored as fields
+2. **Test isolation**: Each test creates fresh service instances
+3. **Mock verification**: `mock.Verify(x => x.Method(), Times.Once)` pattern
+4. **Exception testing**: `Assert.Throws<T>(() => ...)` pattern
+5. **Async testing**: `async Task` test methods with `await`
+6. **Stub implementations**: Lightweight classes implementing interfaces for time/season/player control
+
+---
+
+## Technology Findings
+
+### xUnit Patterns in This Project
+
+```csharp
+// Standard test class structure
+public class ServiceTests
+{
+    private readonly Mock<IDependency> _mockDep;
+    private readonly ServiceUnderTest _service;
+
+    public ServiceTests()
+    {
+        _mockDep = new Mock<IDependency>();
+        _service = new ServiceUnderTest(_mockDep.Object);
+    }
+
+    [Fact]
+    public void Method_State_ExpectedResult()
+    {
+        // Arrange
+        _mockDep.Setup(x => x.Method()).Returns(value);
+        
+        // Act
+        var result = _service.Method();
+        
+        // Assert
+        Assert.Equal(expected, result);
+    }
+}
+```
+
+### Stub Implementation Pattern (New)
+
+```csharp
+// Example: ITimeProvider stub for time-dependent tests
+public class TimeProviderStub : ITimeProvider
+{
+    public int TotalDays { get; set; } = 1;
+}
+
+// Example: ISeasonProvider stub for season-dependent tests
+public class SeasonProviderStub : ISeasonProvider
+{
+    public string CurrentSeason { get; set; } = "spring";
+}
+
+// Example: IPlayerProvider stub for player-dependent tests
+public class PlayerProviderStub : IPlayerProvider
+{
+    public Item? CurrentItem { get; set; }
+}
+```
+
+### ThreadSafeGameLoopEventsStub Usage
+
+```csharp
+// From ModControllerTests
+var threadSafeGameLoopEvents = new ThreadSafeGameLoopEventsStub();
+_mockHelper.Setup(x => x.Events).Returns(mockEvents.Object);
+mockEvents.Setup(x => x.GameLoop).Returns(threadSafeGameLoopEvents);
+
+// Raise events
+mockGameLoopEvents.Raise(x => x.SaveLoaded += null, new SaveLoadedEventArgs());
+```
+
+---
+
+## Dependency Analysis
+
+### Services Under Test
+
+| Service | Dependencies | Mockable? |
+|---------|--------------|-----------|
+| `CompostingBinService` | `IModDataService`, `ISaveIdProvider`, `IOrganicWasteValidator`, `IMonitor`, `ITimeProvider`, `CompostingBinFactory` | Yes — all interface dependencies |
+| `CompostApplicationService` | `ISoilHealthService`, `IMonitor`, `IPlayerProvider` | Yes — all interface dependencies |
+| `SoilDecayService` | `ISoilHealthService`, `IMonitor`, `ISeasonProvider`, `SeasonalDecayMultiplier` | Partial — `SeasonalDecayMultiplier` has no interface |
+| `OrganicWasteValidator` | `IMonitor` | Yes |
+| `SeasonalDecayMultiplier` | None | N/A — no dependencies |
+| `SaveIdProvider` | None | N/A — reads `Constants.SaveFolderName` |
+| `CompostingBinFactory` | None | N/A — creates `CompostingBinStateModel` |
+
+### Key Insight
+
+`SeasonalDecayMultiplier` has no dependencies and no interface — it's a pure function. Tests can call it directly without mocking.
+
+`SaveIdProvider` has no injectable dependencies — it reads from `Constants.SaveFolderName` static. Tests must use reflection to control this value.
+
+---
+
+## Edge Cases Identified
+
+1. **Null item in `AddWaste`**: `OrganicWasteValidator.IsValidOrganicWaste(null)` returns false
+2. **Empty runtime cache**: `ProcessDayStart` on empty location is a no-op
+3. **Collect from empty bin**: Returns 0, no state change
+4. **Collect from processing bin**: Returns 0, no state change
+5. **Add waste to processing bin**: Silently ignored, state unchanged
+6. **Add waste to ready bin**: Silently ignored, state unchanged
+7. **Maturation level cap**: Capped at `MaturationMaxLevel = 5`
+8. **Maturation reset**: After 14 idle days, resets to 1
+9. **Soil health bounds**: Clamped to [0, 100]
+10. **Invalid season**: Returns default multiplier (0.5x)
+
+---
+
+## Open Questions (Resolved During Research)
+
+| Question | Answer |
+|----------|--------|
+| Does `Game1.Date.TotalDays` have a public setter? | Yes — but tests no longer use it directly; they use `ITimeProvider` stub |
+| Does `GameLocation` have a public constructor? | Yes — `GameLocation(string mapPath, string name)` (first param is map path, not display name) |
+| Does `HoeDirt` have a public constructor? | Yes — `HoeDirt(int state, GameLocation location)` |
+| Is `ThreadSafeGameLoopEventsStub` in the test project? | Yes — `LivingRoots.Tests/ThreadSafeGameLoopEventsStub.cs` |
+| Does `Constants.SaveFolderName` have a public setter? | Yes — can be set via reflection |
+| What is the correct `GameLocation` constructor signature? | `GameLocation(string mapPath, string name)` — confirmed via binary analysis |
+| Should `CompostingBinController` be a standalone class? | No — merge into `ModController` and delete standalone class |
+| Should both services be wired to `DayStarted`? | Yes — both `CompostingBinService` and `SoilDecayService` |
+
+---
+
+## Recommendations
+
+1. **Create stub implementations** for `ITimeProvider`, `ISeasonProvider`, `IPlayerProvider` — lightweight classes with settable properties
+2. **Use existing `ThreadSafeGameLoopEventsStub`** for event wiring tests
+3. **Use reflection for `Constants.SaveFolderName`** in `SaveIdProviderTests`
+4. **Follow existing test patterns** from `ModControllerTests` and `ModDataServiceTests`
+5. **Use correct `GameLocation` constructor signature**: `new GameLocation("Maps\\Farm", "Farm")`
+6. **Persist `ConsecutiveActiveDays`** in `CompostingBinData` before writing maturation tests
+7. **Make `CompostingBinFactory`** the single creation point for `CompostingBinStateModel`


### PR DESCRIPTION
## Summary
Adds documentation artifacts for the composting test feature: research findings, data model, test fixture contracts, test patterns, and quickstart validation scenarios. These docs define the testing approach and shared infrastructure contracts used by the composting test suite.

## Changes
- : Research outcomes for testing Game1 dependencies, time-dependent transitions, and maturation mechanics
- : Entity definitions, fields, relationships, and state transitions for composting bin models
- : Test fixture contracts (TimeProviderStub, SeasonProviderStub, PlayerProviderStub, GameLocationFixture, ItemFactory)
- : Six test patterns for service mocking, time control, location iteration, event testing, reflection, and season-dependent tests
- : Runnable validation scenarios for end-to-end correctness

## Story position
PR 1 of 3 for  follow-up. This PR sets up documentation. The next PR will update existing tests for the new ModController constructor.

## Build status
Documentation-only PR. No code changes; builds cleanly on its own.