### PR TITLE
test(controller): update existing tests for new ModController constructor (PR 2/3)

### DIFF
--- a/LivingRoots.Tests/ConcurrentRegisterUnregisterRaceConditionTest.cs
+++ b/LivingRoots.Tests/ConcurrentRegisterUnregisterRaceConditionTest.cs
@@ -15,6 +15,8 @@ namespace LivingRoots.Tests
         private readonly Mock<IManifest> _mockManifest;
         private readonly Mock<ISoilHealthService> _mockSoilHealthService;
         private readonly Mock<ISaveIdProvider> _mockSaveIdProvider;
+        private readonly Mock<ICompostingBinService> _mockCompostingBinService;
+        private readonly Mock<ISoilDecayService> _mockSoilDecayService;
 
         public ConcurrentRegisterUnregisterRaceConditionTest()
         {
@@ -23,6 +25,8 @@ namespace LivingRoots.Tests
             _mockManifest = new Mock<IManifest>();
             _mockSoilHealthService = new Mock<ISoilHealthService>();
             _mockSaveIdProvider = new Mock<ISaveIdProvider>();
+            _mockCompostingBinService = new Mock<ICompostingBinService>();
+            _mockSoilDecayService = new Mock<ISoilDecayService>();
 
             // Add default setup for _mockManifest properties to prevent NullReferenceException
             _mockManifest.Setup(x => x.UniqueID).Returns("test.mod.id");
@@ -43,7 +47,7 @@ namespace LivingRoots.Tests
 
             // Create a single ModController instance to be shared across all tasks
             var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object,
-                _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+                _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // First register events to set up the controller with handlers
             controller.RegisterEvents();
@@ -142,7 +146,7 @@ namespace LivingRoots.Tests
 
             // Create a single ModController instance to be shared across all tasks
             var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object,
-                _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+                _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // First register events to set up the controller with handlers
             controller.RegisterEvents();

--- a/LivingRoots.Tests/ModControllerTests.cs
+++ b/LivingRoots.Tests/ModControllerTests.cs
@@ -21,6 +21,8 @@ namespace LivingRoots.Tests
         private readonly Mock<IManifest> _mockManifest;
         private readonly Mock<ISoilHealthService> _mockSoilHealthService;
         private readonly Mock<ISaveIdProvider> _mockSaveIdProvider;
+        private readonly Mock<ICompostingBinService> _mockCompostingBinService;
+        private readonly Mock<ISoilDecayService> _mockSoilDecayService;
 
         public ModControllerTests()
         {
@@ -29,6 +31,8 @@ namespace LivingRoots.Tests
             _mockManifest = new Mock<IManifest>();
             _mockSoilHealthService = new Mock<ISoilHealthService>();
             _mockSaveIdProvider = new Mock<ISaveIdProvider>();
+            _mockCompostingBinService = new Mock<ICompostingBinService>();
+            _mockSoilDecayService = new Mock<ISoilDecayService>();
 
             // Add default setup for _mockManifest properties to prevent NullReferenceException
             _mockManifest.Setup(x => x.UniqueID).Returns("test.mod.id");
@@ -38,31 +42,43 @@ namespace LivingRoots.Tests
         [Fact]
         public void Constructor_WithNullHelper_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new ModController(null!, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object));
+            Assert.Throws<ArgumentNullException>(() => new ModController(null!, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object));
         }
 
         [Fact]
         public void Constructor_WithNullMonitor_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, null!, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object));
+            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, null!, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object));
         }
 
         [Fact]
         public void Constructor_WithNullManifest_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, _mockMonitor.Object, null!, _mockSoilHealthService.Object, _mockSaveIdProvider.Object));
+            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, _mockMonitor.Object, null!, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object));
         }
 
         [Fact]
         public void Constructor_WithNullSoilHealthService_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, null!, _mockSaveIdProvider.Object));
+            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, null!, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object));
         }
 
         [Fact]
         public void Constructor_WithNullSaveIdProvider_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, null!));
+            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, null!, _mockCompostingBinService.Object, _mockSoilDecayService.Object));
+        }
+
+        [Fact]
+        public void Constructor_WithNullCompostingBinService_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, null!, _mockSoilDecayService.Object));
+        }
+
+        [Fact]
+        public void Constructor_WithNullSoilDecayService_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, null!));
         }
 
         [Fact]
@@ -77,7 +93,7 @@ namespace LivingRoots.Tests
             mockEvents.Setup(x => x.GameLoop).Returns(mockGameLoopEvents.Object);
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Act & Assert - Should not throw when controller is properly constructed
             var ex = Record.Exception(() => controller.RegisterEvents());
@@ -93,7 +109,7 @@ namespace LivingRoots.Tests
             _mockHelper.Setup(x => x.Events).Returns((IModEvents)null!); // Return null for Events
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Act & Assert - Should not throw when Events is null
             var ex = Record.Exception(() => controller.RegisterEvents());
@@ -111,7 +127,7 @@ namespace LivingRoots.Tests
             mockEvents.Setup(x => x.GameLoop).Returns((IGameLoopEvents)null!); // Return null for GameLoop
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Act & Assert - Should not throw when GameLoop is null
             var ex = Record.Exception(() => controller.RegisterEvents());
@@ -131,7 +147,7 @@ namespace LivingRoots.Tests
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
             // Create a single ModController instance to be shared across all tasks
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Act - Simulate concurrent registration attempts on the same instance
             var tasks = new List<System.Threading.Tasks.Task>();
@@ -171,7 +187,7 @@ namespace LivingRoots.Tests
                 .SetupAdd(x => x.GameLaunched += It.IsAny<EventHandler<GameLaunchedEventArgs>>())
                 .Throws(new Exception("Test exception"));
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Act & Assert - Should handle exception gracefully and not propagate
             var ex = Record.Exception(() => controller.RegisterEvents());
@@ -199,7 +215,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupRemove(x => x.SaveLoaded -= It.IsAny<EventHandler<SaveLoadedEventArgs>>());
             mockGameLoopEvents.SetupRemove(x => x.Saving -= It.IsAny<EventHandler<SavingEventArgs>>());
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // First register events to set up the controller
             controller.RegisterEvents();
@@ -225,7 +241,7 @@ namespace LivingRoots.Tests
             mockEvents.Setup(x => x.GameLoop).Returns(mockGameLoopEvents.Object);
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Act
             controller.UnregisterEvents();
@@ -249,7 +265,7 @@ namespace LivingRoots.Tests
             mockEvents.Setup(x => x.GameLoop).Returns(threadSafeGameLoopEvents);
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // First register events to set up the controller
             controller.RegisterEvents();
@@ -296,7 +312,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupRemove(x => x.SaveLoaded -= It.IsAny<EventHandler<SaveLoadedEventArgs>>());
             mockGameLoopEvents.SetupRemove(x => x.Saving -= It.IsAny<EventHandler<SavingEventArgs>>());
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // First register events to initialize the controller
             controller.RegisterEvents();
@@ -335,7 +351,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupRemove(x => x.SaveLoaded -= It.IsAny<EventHandler<SaveLoadedEventArgs>>());
             mockGameLoopEvents.SetupRemove(x => x.Saving -= It.IsAny<EventHandler<SavingEventArgs>>());
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // First register events to initialize the controller
             controller.RegisterEvents();
@@ -370,7 +386,7 @@ namespace LivingRoots.Tests
             mockEvents.Setup(x => x.GameLoop).Returns(mockGameLoopEvents.Object);
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events first to initialize the command registration
             controller.RegisterEvents();
@@ -394,7 +410,7 @@ namespace LivingRoots.Tests
             mockEvents.Setup(x => x.GameLoop).Returns(mockGameLoopEvents.Object);
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events first to initialize the command registration
             controller.RegisterEvents();
@@ -429,7 +445,7 @@ namespace LivingRoots.Tests
             mockEvents.Setup(x => x.GameLoop).Returns(mockGameLoopEvents.Object);
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events first to initialize the command registration
             controller.RegisterEvents();
@@ -467,7 +483,7 @@ namespace LivingRoots.Tests
             // Mock the save ID provider to return a valid save ID
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns("test_save_id");
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events to ensure proper setup before calling OnSaveLoaded
             controller.RegisterEvents();
@@ -494,7 +510,7 @@ namespace LivingRoots.Tests
             // Mock the save ID provider to return a valid save ID
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns("test_save_id");
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events to ensure proper setup before calling OnSaving
             controller.RegisterEvents();
@@ -519,7 +535,7 @@ namespace LivingRoots.Tests
             _mockHelper.Setup(x => x.Events).Returns(mockEvents.Object);
             mockEvents.Setup(x => x.GameLoop).Returns(mockGameLoopEvents.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Act & Assert - Initially should not be disposed
             // Verify that controller can be used before disposal
@@ -552,7 +568,7 @@ namespace LivingRoots.Tests
         public void TrySetStateFlag_SetsFlagAtomically()
         {
             // Arrange
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
             const int testFlag = ModController.EventsRegisteredFlag;
 
             // Act
@@ -584,7 +600,7 @@ namespace LivingRoots.Tests
             mockEvents.Setup(x => x.GameLoop).Returns(mockGameLoopEvents.Object);
             _mockHelper.Setup(x => x.ConsoleCommands).Returns(mockCommandHelper.Object);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Act - Dispose the controller
             controller.Dispose();
@@ -614,7 +630,7 @@ namespace LivingRoots.Tests
             // Mock SaveIdProvider to return null (simulating unavailable save folder)
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns((string?)null);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events to ensure proper setup
             controller.RegisterEvents();
@@ -643,7 +659,7 @@ namespace LivingRoots.Tests
             // Mock SaveIdProvider to return null (simulating unavailable save folder)
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns((string?)null);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events to ensure proper setup
             controller.RegisterEvents();
@@ -682,7 +698,7 @@ namespace LivingRoots.Tests
             const string expectedSaveId = "test_save_12345";
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns(expectedSaveId);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events to ensure proper setup before triggering SaveLoaded
             controller.RegisterEvents();
@@ -724,7 +740,7 @@ namespace LivingRoots.Tests
             const string expectedSaveId = "test_save_67890";
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns(expectedSaveId);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events to ensure proper setup before triggering Saving
             controller.RegisterEvents();
@@ -767,7 +783,7 @@ namespace LivingRoots.Tests
             const string expectedSaveId = "test_save_complete_flow";
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns(expectedSaveId);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events to ensure proper setup
             controller.RegisterEvents();
@@ -810,7 +826,7 @@ namespace LivingRoots.Tests
             // Mock SaveIdProvider to return null (simulating unavailable save folder)
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns((string?)null);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events to ensure proper setup
             controller.RegisterEvents();
@@ -850,7 +866,7 @@ namespace LivingRoots.Tests
             // Mock SaveIdProvider to return empty string (simulating unavailable save folder)
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns(string.Empty);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events to ensure proper setup
             controller.RegisterEvents();
@@ -891,7 +907,7 @@ namespace LivingRoots.Tests
             const string complexSaveId = "Save_2024-01-15_FarmerName_123";
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns(complexSaveId);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events to ensure proper setup
             controller.RegisterEvents();
@@ -932,7 +948,7 @@ namespace LivingRoots.Tests
             const string expectedSaveId = "test_save_multiple";
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns(expectedSaveId);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events to ensure proper setup
             controller.RegisterEvents();
@@ -972,7 +988,7 @@ namespace LivingRoots.Tests
             const string expectedSaveId = "test_save_multiple_saves";
             _mockSaveIdProvider.Setup(x => x.GetSaveId()).Returns(expectedSaveId);
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events to ensure proper setup
             controller.RegisterEvents();

--- a/LivingRoots.Tests/ModEntryTests.cs
+++ b/LivingRoots.Tests/ModEntryTests.cs
@@ -66,13 +66,17 @@ namespace LivingRoots.Tests
             var mockManifest = new Mock<IManifest>();
             var mockSoilHealthService = new Mock<ISoilHealthService>();
             var mockSaveIdProvider = new Mock<ISaveIdProvider>();
+            var mockCompostingBinService = new Mock<ICompostingBinService>();
+            var mockSoilDecayService = new Mock<ISoilDecayService>();
 
             var controller = new ModController(
                 mockHelper.Object,
                 mockMonitor.Object,
                 mockManifest.Object,
                 mockSoilHealthService.Object,
-                mockSaveIdProvider.Object);
+                mockSaveIdProvider.Object,
+                mockCompostingBinService.Object,
+                mockSoilDecayService.Object);
 
             // Set the controller field directly using reflection
             var controllerField = typeof(ModEntry).GetField("_controller", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -103,13 +107,17 @@ namespace LivingRoots.Tests
             var mockManifest = new Mock<IManifest>();
             var mockSoilHealthService = new Mock<ISoilHealthService>();
             var mockSaveIdProvider = new Mock<ISaveIdProvider>();
+            var mockCompostingBinService = new Mock<ICompostingBinService>();
+            var mockSoilDecayService = new Mock<ISoilDecayService>();
 
             var controller = new ModController(
                 mockHelper.Object,
                 mockMonitor.Object,
                 mockManifest.Object,
                 mockSoilHealthService.Object,
-                mockSaveIdProvider.Object);
+                mockSaveIdProvider.Object,
+                mockCompostingBinService.Object,
+                mockSoilDecayService.Object);
 
             // Set the controller field directly using reflection
             var controllerField = typeof(ModEntry).GetField("_controller", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -139,13 +147,17 @@ namespace LivingRoots.Tests
             var mockManifest = new Mock<IManifest>();
             var mockSoilHealthService = new Mock<ISoilHealthService>();
             var mockSaveIdProvider = new Mock<ISaveIdProvider>();
+            var mockCompostingBinService = new Mock<ICompostingBinService>();
+            var mockSoilDecayService = new Mock<ISoilDecayService>();
 
             var controller = new ModController(
                 mockHelper.Object,
                 mockMonitor.Object,
                 mockManifest.Object,
                 mockSoilHealthService.Object,
-                mockSaveIdProvider.Object);
+                mockSaveIdProvider.Object,
+                mockCompostingBinService.Object,
+                mockSoilDecayService.Object);
 
             // Set the controller field directly using reflection
             var controllerField = typeof(ModEntry).GetField("_controller", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -210,13 +222,17 @@ namespace LivingRoots.Tests
             var mockManifest = new Mock<IManifest>();
             var mockSoilHealthService = new Mock<ISoilHealthService>();
             var mockSaveIdProvider = new Mock<ISaveIdProvider>();
+            var mockCompostingBinService = new Mock<ICompostingBinService>();
+            var mockSoilDecayService = new Mock<ISoilDecayService>();
 
             var controller = new ModController(
                 mockHelper.Object,
                 mockMonitor.Object,
                 mockManifest.Object,
                 mockSoilHealthService.Object,
-                mockSaveIdProvider.Object);
+                mockSaveIdProvider.Object,
+                mockCompostingBinService.Object,
+                mockSoilDecayService.Object);
 
             // Set the controller field directly using reflection
             var controllerField = typeof(ModEntry).GetField("_controller", BindingFlags.NonPublic | BindingFlags.Instance);

--- a/LivingRoots.Tests/RegisterEventsRaceConditionTest.cs
+++ b/LivingRoots.Tests/RegisterEventsRaceConditionTest.cs
@@ -15,6 +15,8 @@ namespace LivingRoots.Tests
         private readonly Mock<IManifest> _mockManifest;
         private readonly Mock<ISoilHealthService> _mockSoilHealthService;
         private readonly Mock<ISaveIdProvider> _mockSaveIdProvider;
+        private readonly Mock<ICompostingBinService> _mockCompostingBinService;
+        private readonly Mock<ISoilDecayService> _mockSoilDecayService;
 
         public RegisterEventsRaceConditionTest()
         {
@@ -23,6 +25,8 @@ namespace LivingRoots.Tests
             _mockManifest = new Mock<IManifest>();
             _mockSoilHealthService = new Mock<ISoilHealthService>();
             _mockSaveIdProvider = new Mock<ISaveIdProvider>();
+            _mockCompostingBinService = new Mock<ICompostingBinService>();
+            _mockSoilDecayService = new Mock<ISoilDecayService>();
 
             // Add default setup for _mockManifest properties to prevent NullReferenceException
             _mockManifest.Setup(x => x.UniqueID).Returns("test.mod.id");
@@ -43,7 +47,7 @@ namespace LivingRoots.Tests
 
             // Create a single ModController instance to be shared across all tasks
             var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object,
-                _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+                _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // First register events to set up the controller with handlers
             controller.RegisterEvents();
@@ -131,7 +135,7 @@ namespace LivingRoots.Tests
 
             // Create a single ModController instance to be shared across all tasks
             var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object,
-                _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+                _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Act: Simulate multiple concurrent registration attempts
             // This should reveal the race condition where multiple threads pass the

--- a/LivingRoots.Tests/UnregisterEventsDuringDisposalTests.cs
+++ b/LivingRoots.Tests/UnregisterEventsDuringDisposalTests.cs
@@ -19,6 +19,8 @@ namespace LivingRoots.Tests
         private readonly Mock<IManifest> _mockManifest;
         private readonly Mock<ISoilHealthService> _mockSoilHealthService;
         private readonly Mock<ISaveIdProvider> _mockSaveIdProvider;
+        private readonly Mock<ICompostingBinService> _mockCompostingBinService;
+        private readonly Mock<ISoilDecayService> _mockSoilDecayService;
 
         public UnregisterEventsDuringDisposalTests()
         {
@@ -27,6 +29,8 @@ namespace LivingRoots.Tests
             _mockManifest = new Mock<IManifest>();
             _mockSoilHealthService = new Mock<ISoilHealthService>();
             _mockSaveIdProvider = new Mock<ISaveIdProvider>();
+            _mockCompostingBinService = new Mock<ICompostingBinService>();
+            _mockSoilDecayService = new Mock<ISoilDecayService>();
 
             // Add default setup for _mockManifest properties to prevent NullReferenceException
             _mockManifest.Setup(x => x.UniqueID).Returns("test.mod.id");
@@ -73,7 +77,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupAdd(x => x.Saving += It.IsAny<EventHandler<SavingEventArgs>>())
                 .Callback<EventHandler<SavingEventArgs>>(h => { });
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events first to set up the controller
             controller.RegisterEvents();
@@ -138,7 +142,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupAdd(x => x.Saving += It.IsAny<EventHandler<SavingEventArgs>>())
                 .Callback<EventHandler<SavingEventArgs>>(h => { });
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events first to set up the controller
             controller.RegisterEvents();
@@ -204,7 +208,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupAdd(x => x.Saving += It.IsAny<EventHandler<SavingEventArgs>>())
                 .Callback<EventHandler<SavingEventArgs>>(h => { });
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events first to set up the controller
             controller.RegisterEvents();

--- a/LivingRoots.Tests/UnregisterEventsRollbackTests.cs
+++ b/LivingRoots.Tests/UnregisterEventsRollbackTests.cs
@@ -19,6 +19,8 @@ namespace LivingRoots.Tests
         private readonly Mock<IManifest> _mockManifest;
         private readonly Mock<ISoilHealthService> _mockSoilHealthService;
         private readonly Mock<ISaveIdProvider> _mockSaveIdProvider;
+        private readonly Mock<ICompostingBinService> _mockCompostingBinService;
+        private readonly Mock<ISoilDecayService> _mockSoilDecayService;
 
         public UnregisterEventsRollbackTests()
         {
@@ -27,6 +29,8 @@ namespace LivingRoots.Tests
             _mockManifest = new Mock<IManifest>();
             _mockSoilHealthService = new Mock<ISoilHealthService>();
             _mockSaveIdProvider = new Mock<ISaveIdProvider>();
+            _mockCompostingBinService = new Mock<ICompostingBinService>();
+            _mockSoilDecayService = new Mock<ISoilDecayService>();
 
             // Add default setup for _mockManifest properties to prevent NullReferenceException
             _mockManifest.Setup(x => x.UniqueID).Returns("test.mod.id");
@@ -88,7 +92,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupRemove(x => x.Saving -= It.IsAny<EventHandler<SavingEventArgs>>())
                 .Callback<EventHandler<SavingEventArgs>>(h => { });
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events first to set up the controller
             controller.RegisterEvents();
@@ -143,7 +147,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupRemove(x => x.Saving -= It.IsAny<EventHandler<SavingEventArgs>>())
                 .Throws(new InvalidOperationException("Saving unsubscribe failed"));
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events first to set up the controller
             controller.RegisterEvents();
@@ -197,7 +201,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupRemove(x => x.Saving -= It.IsAny<EventHandler<SavingEventArgs>>())
                 .Callback<EventHandler<SavingEventArgs>>(h => { });
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events first to set up the controller
             controller.RegisterEvents();
@@ -249,7 +253,7 @@ namespace LivingRoots.Tests
             mockGameLoopEvents.SetupRemove(x => x.Saving -= It.IsAny<EventHandler<SavingEventArgs>>())
                 .Callback<EventHandler<SavingEventArgs>>(h => { });
 
-            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object);
+            var controller = new ModController(_mockHelper.Object, _mockMonitor.Object, _mockManifest.Object, _mockSoilHealthService.Object, _mockSaveIdProvider.Object, _mockCompostingBinService.Object, _mockSoilDecayService.Object);
 
             // Register events first to set up the controller
             controller.RegisterEvents();

--- a/LivingRoots.Tests/Visualization/ModControllerVisualizationTests.cs
+++ b/LivingRoots.Tests/Visualization/ModControllerVisualizationTests.cs
@@ -18,6 +18,8 @@ namespace LivingRoots.Tests.Visualization
             var mockManifest = new Mock<IManifest>();
             var mockSoilService = new Mock<ISoilHealthService>();
             var mockSaveIdProvider = new Mock<ISaveIdProvider>();
+            var mockCompostingBinService = new Mock<ICompostingBinService>();
+            var mockSoilDecayService = new Mock<ISoilDecayService>();
             var mockVisService = new Mock<IVisualizationService>();
             var mockConfigService = new Mock<IVisualizationConfigurationService>();
 
@@ -28,6 +30,7 @@ namespace LivingRoots.Tests.Visualization
             var controller = new Controllers.ModController(
                 mockHelper.Object, mockMonitor.Object, mockManifest.Object,
                 mockSoilService.Object, mockSaveIdProvider.Object,
+                mockCompostingBinService.Object, mockSoilDecayService.Object,
                 mockVisService.Object, mockConfigService.Object);
         }
     }


### PR DESCRIPTION
## Summary
Updates seven existing test files to match the new ModController constructor signature, which now accepts ICompostingBinService and ISoilDecayService dependencies. Ensures all tests continue to compile and pass after the composting feature integration.

## Changes
- : Injects new mocks, adds null validation tests for new parameters
- : Updates test fixtures with new mock dependencies
- : Updates constructor calls
- : Updates constructor calls
- : Updates constructor calls
- : Updates constructor calls
- : Updates constructor calls

## Story position
PR 2 of 3 for  follow-up. This PR fixes existing tests. The next PR adds repository maintenance updates.

## Build status
Builds cleanly on its own once the prior PRs in this chain are merged.